### PR TITLE
chore(ci): drop private-registry credentials from the OpenShift path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -397,9 +397,16 @@ jobs:
       - core
       - operator
       - olm
-    if: needs.change-triage.outputs.run-openshift == 'true'
+    # OPENSHIFT_ENABLED gates the job on repositories that have the Red Hat
+    # pull secret configured. Forks do not set the variable, so the job is
+    # skipped there instead of failing to start the CRC cluster. A fork can
+    # opt in by setting the variable and the REDHAT_PULL
+    # secret.
+    if: |
+      needs.change-triage.outputs.run-openshift == 'true' &&
+      vars.OPENSHIFT_ENABLED == 'true'
     uses: ./.github/workflows/openshift-e2e.yml
     with:
       catalog-artifact-name: klio-olm
     secrets:
-      REDHAT_REGISTRY_DOCKERCONFIG: ${{ secrets.REDHAT_REGISTRY_DOCKERCONFIG }}
+      REDHAT_PULL: ${{ secrets.REDHAT_PULL }}

--- a/.github/workflows/openshift-e2e.yml
+++ b/.github/workflows/openshift-e2e.yml
@@ -8,9 +8,12 @@ on:
         type: string
         required: true
     secrets:
-      REDHAT_REGISTRY_DOCKERCONFIG:
+      REDHAT_PULL:
         description: "Red Hat pull secret used to start the CRC cluster."
-        required: true
+        # Not required: forks have no Red Hat pull secret, so the caller gates
+        # this workflow on the OPENSHIFT_ENABLED repository variable and only
+        # repositories that opted in (and configured the secret) ever reach it.
+        required: false
 
 permissions:
   contents: read
@@ -23,8 +26,6 @@ jobs:
     timeout-minutes: 120
     env:
       ENVIRONMENT: "testing"
-      GHCR_USERNAME: ${{ github.actor }}
-      GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -52,7 +53,7 @@ jobs:
       - name: Start OpenShift cluster (CRC)
         uses: crc-org/crc-github-action@c32030519c129bdaeedf2f313670831c2195526e # v1
         with:
-          pull-secret: ${{ secrets.REDHAT_REGISTRY_DOCKERCONFIG }}
+          pull-secret: ${{ secrets.REDHAT_PULL }}
           preset: openshift
           cpus: 8
           memory: 20480
@@ -72,11 +73,21 @@ jobs:
       - name: Setup dagger
         uses: ./.github/actions/setup-dagger
 
+      - name: Login to ghcr.io
+        # The Klio images are public, but anonymous pulls share a per-IP rate
+        # limit across all GitHub Actions runners and can be throttled during a
+        # burst. GITHUB_TOKEN is auto-provisioned (forks included), so this needs
+        # no gating; it only grants the read access the pulls below require.
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Run Red Hat preflight (check operator)
         # Certify the OLM bundle on the freshly started cluster, before the e2e
         # suite installs the operator. preflight installs into its own namespace,
         # so it stays isolated from the e2e install in openshift-operators.
-        continue-on-error: true
         run: task olm:preflight-operator ENVIRONMENT=testing
 
       - name: Run e2e tests on OpenShift

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -472,50 +472,6 @@ tasks:
         --args "--save_path=licenses/go-licenses" --args "--ignore=github.com/cloudnative-pg/klio"
         directory --path licenses/ export --path licenses/
 
-  internal:ensure-ghcr-pull-secret:
-    desc: Add GHCR credentials to the OpenShift cluster-wide pull secret
-    internal: true
-    run: once
-    requires:
-      vars:
-        # EXTERNAL_KUBECONFIG points at the OpenShift cluster whose global pull
-        # secret is updated; GHCR_USERNAME/GHCR_TOKEN build the credential.
-        - EXTERNAL_KUBECONFIG
-        - GHCR_USERNAME
-        - GHCR_TOKEN
-    env:
-      KUBECONFIG: '{{ .EXTERNAL_KUBECONFIG }}'
-      GHCR_USERNAME: '{{ .GHCR_USERNAME }}'
-      GHCR_TOKEN: '{{ .GHCR_TOKEN }}'
-    cmds:
-      - |
-        set -euo pipefail
-        # Add GHCR credentials to the cluster-wide pull secret so the kubelet can
-        # pull the private Klio operator/bundle/operand images on every node.
-        # Required on both OLM install paths (preflight check operator and the
-        # e2e deploy): pods OLM creates fall back to the ServiceAccount dockercfg,
-        # which only covers the internal registry, so without this the private
-        # ghcr.io images fail to pull.
-
-        # Build the GHCR dockerconfigjson explicitly rather than reading
-        # ~/.docker/config.json, which may use a credential helper that omits the
-        # inline auth string.
-        ghcr_secret=$(mktemp)
-        global_secret=$(mktemp)
-        merged_secret=$(mktemp)
-        trap 'rm -f "${ghcr_secret}" "${global_secret}" "${merged_secret}"' EXIT
-        auth=$(printf '%s:%s' "${GHCR_USERNAME}" "${GHCR_TOKEN}" | base64 | tr -d '\n')
-        printf '{"auths":{"ghcr.io":{"auth":"%s"}}}' "${auth}" > "${ghcr_secret}"
-
-        kubectl get secret pull-secret -n openshift-config \
-          -o jsonpath='{.data.\.dockerconfigjson}' | base64 -d > "${global_secret}"
-        jq -s '.[0] * .[1]' "${global_secret}" "${ghcr_secret}" > "${merged_secret}"
-        kubectl create secret generic pull-secret \
-          --type=kubernetes.io/dockerconfigjson \
-          --from-file=.dockerconfigjson="${merged_secret}" \
-          -n openshift-config \
-          --dry-run=client -o yaml | kubectl apply -f -
-
   ####################################
   ## OPERATOR
   ####################################
@@ -974,8 +930,6 @@ tasks:
         spec:
            sourceType: grpc
            image: ${registry}/klio-operator${suffix}:${tag}-catalog
-           secrets:
-               - klio-pull-secret
         EOF
 
   olm:preflight-container:
@@ -991,31 +945,18 @@ tasks:
         # re-deriving the image name per environment.
         - IMAGE
     env:
-      # REGISTRY_AUTH_FILE is the fallback registry credentials file used to pull
-      # the image under test (same convention as the OLM tasks).
+      # REGISTRY_AUTH_FILE is the registry credentials file used to pull the
+      # image under test (same convention as the OLM tasks). The published
+      # ghcr.io images are public, so it is only needed for private or local
+      # registries.
       REGISTRY_AUTH_FILE: '{{ .REGISTRY_AUTH_FILE | default (printf "%s/.docker/config.json" (env "HOME")) }}'
-      GHCR_USERNAME: '{{ .GHCR_USERNAME | default "" }}'
-      GHCR_TOKEN: '{{ .GHCR_TOKEN | default "" }}'
     # Preflight runs and the results are evaluated entirely inside the Dagger
     # engine: the `verdict` call fails on a non-passing check. Nothing is
     # written to the host.
     cmds:
       - |
         set -euo pipefail
-        # Resolve a docker config for the pull. Prefer building it from
-        # GHCR_USERNAME/GHCR_TOKEN when set: ~/.docker/config.json often relies on
-        # a credential helper that omits the inline auth string (e.g. Docker
-        # Desktop on macOS), so reading it directly is unreliable for local/CRC
-        # runs. This matches integration:deploy-to-openshift. Fall back to
-        # REGISTRY_AUTH_FILE otherwise (e.g. CI, where `docker login` writes an
-        # inline auth).
         dockerconfig="${REGISTRY_AUTH_FILE}"
-        if [ -n "${GHCR_USERNAME:-}" ] && [ -n "${GHCR_TOKEN:-}" ]; then
-          dockerconfig="$(mktemp)"
-          trap 'rm -f "${dockerconfig}"' EXIT
-          auth="$(printf '%s:%s' "${GHCR_USERNAME}" "${GHCR_TOKEN}" | base64 | tr -d '\n')"
-          printf '{"auths":{"ghcr.io":{"auth":"%s"}}}' "${auth}" > "${dockerconfig}"
-        fi
         docker_config_arg=""
         if [ -f "${dockerconfig}" ]; then
           docker_config_arg="--docker-config file://${dockerconfig}"
@@ -1037,10 +978,8 @@ tasks:
       host-side against EXTERNAL_KUBECONFIG (like the other CRC tasks) and only
       the pass/fail verdict is evaluated in-engine via the preflight module.
 
-      Dry run (default) evaluates the checks without contacting Red Hat. Set
-      SUBMIT=true (with PFLT_PYXIS_API_TOKEN and PFLT_CERTIFICATION_COMPONENT_ID
-      exported) to submit the results to Red Hat Pyxis; this is intended for
-      releases only.
+      The checks are always evaluated locally; nothing is ever submitted to
+      Red Hat.
     dir: operator
     run: once
     requires:
@@ -1049,37 +988,23 @@ tasks:
         # installs the operator into. Named like the other CRC tasks so a run
         # can share the same cluster.
         - EXTERNAL_KUBECONFIG
-        # GHCR_USERNAME/GHCR_TOKEN authenticate the private Klio image pulls:
-        # both preflight's own bundle/index pulls and (via the dependency below)
-        # the cluster-wide pull secret the kubelet uses for the operator pod.
-        - GHCR_USERNAME
-        - GHCR_TOKEN
         - name: ENVIRONMENT
           enum:
             ref: .ALLOWED_ENVS
-    deps:
-      - task: internal:ensure-ghcr-pull-secret
-        vars:
-          EXTERNAL_KUBECONFIG: '{{ .EXTERNAL_KUBECONFIG }}'
-          GHCR_USERNAME: '{{ .GHCR_USERNAME }}'
-          GHCR_TOKEN: '{{ .GHCR_TOKEN }}'
     env:
       registry: '{{ if .GITHUB_ACTIONS }}ghcr.io/cloudnative-pg{{ else }}{{ .REGISTRY_NAME }}:{{ .REGISTRY_PORT }}{{ end }}'
       suffix: '{{ if ( ne .ENVIRONMENT "production" ) }}-testing{{end}}'
       tag: '{{ .TAG | default .IMAGE_TAG }}'
-      # GHCR_USERNAME/GHCR_TOKEN build the docker config for the bundle/index
-      # pulls and feed the cluster pull secret via the
-      # internal:ensure-ghcr-pull-secret dependency. The OpenShift E2E CI job
-      # sets both.
-      GHCR_USERNAME: '{{ .GHCR_USERNAME }}'
-      GHCR_TOKEN: '{{ .GHCR_TOKEN }}'
+      # REGISTRY_AUTH_FILE is the registry credentials file preflight uses for
+      # its bundle and index pulls (same convention as the other OLM tasks). The
+      # ghcr.io images are public, so it is optional and skipped when absent,
+      # but an authenticated pull avoids the per-IP anonymous rate limit shared
+      # across GitHub Actions runners. CI populates it with `docker login`.
+      REGISTRY_AUTH_FILE: '{{ .REGISTRY_AUTH_FILE | default (printf "%s/.docker/config.json" (env "HOME")) }}'
       # Export EXTERNAL_KUBECONFIG (otherwise only a required var) so the recipe
       # below can reference it: with `set -u` an unexported var passed on the
       # command line rather than via the environment would abort as unbound.
       EXTERNAL_KUBECONFIG: '{{ .EXTERNAL_KUBECONFIG }}'
-    vars:
-      # SUBMIT toggles submission to Red Hat Pyxis. Dry run by default.
-      SUBMIT: '{{ .SUBMIT | default "false" }}'
     cmds:
       - |
         set -euo pipefail
@@ -1092,27 +1017,6 @@ tasks:
         rm -rf "${artifacts}"
         mkdir -p "${artifacts}"
 
-        # Build the docker config for the bundle/index pulls from
-        # GHCR_USERNAME/GHCR_TOKEN (required vars). We construct it explicitly
-        # rather than reading ~/.docker/config.json, which may use a credential
-        # helper that omits the inline auth string (e.g. Docker Desktop on
-        # macOS). This matches integration:deploy-to-openshift.
-        dockerconfig="$(mktemp)"
-        trap 'rm -f "${dockerconfig}"' EXIT
-        auth="$(printf '%s:%s' "${GHCR_USERNAME}" "${GHCR_TOKEN}" | base64 | tr -d '\n')"
-        printf '{"auths":{"ghcr.io":{"auth":"%s"}}}' "${auth}" > "${dockerconfig}"
-
-        docker_config="-e PFLT_DOCKERCONFIG=/dockerconfig -v ${dockerconfig}:/dockerconfig:ro"
-
-        submit=""
-        submit_env=""
-        if [ "{{ .SUBMIT }}" = "true" ]; then
-          : "${PFLT_PYXIS_API_TOKEN:?must be exported to submit results}"
-          : "${PFLT_CERTIFICATION_COMPONENT_ID:?must be exported to submit results}"
-          submit="--submit"
-          submit_env="-e PFLT_PYXIS_API_TOKEN -e PFLT_CERTIFICATION_COMPONENT_ID"
-        fi
-
         # preflight must reach the OpenShift API server named in the kubeconfig
         # (e.g. api.crc.testing). On Linux --network host shares the host network
         # directly (as CI does). On macOS --network host joins the Docker Desktop
@@ -1124,6 +1028,13 @@ tasks:
           net_args="--add-host=${api_host}:host-gateway"
         fi
 
+        # Hand preflight the registry credentials when a config file exists, so
+        # the bundle and index pulls are authenticated rather than anonymous.
+        docker_config_args=""
+        if [ -f "${REGISTRY_AUTH_FILE}" ]; then
+          docker_config_args="-e PFLT_DOCKERCONFIG=/dockerconfig -v ${REGISTRY_AUTH_FILE}:/dockerconfig:ro"
+        fi
+
         # The bundle, index and preflight images are all multi-arch, so docker
         # selects the host-architecture variant and preflight runs natively (no
         # emulation) — on an arm64 host it certifies the arm64 images end to end.
@@ -1133,9 +1044,9 @@ tasks:
           -e PFLT_INDEXIMAGE="${index}" \
           -e PFLT_SCORECARD_WAIT_TIME=1200 \
           -e PFLT_ARTIFACTS=/artifacts -v "$(pwd)/${artifacts}:/artifacts" \
-          ${docker_config} ${submit_env} \
+          ${docker_config_args} \
           quay.io/opdev/preflight:{{ .PREFLIGHT_VERSION }} \
-          check operator "${bundle}" ${submit}
+          check operator "${bundle}"
       # preflight exits non-zero only when it fails to run, not when checks fail,
       # so the verdict is derived from the artifacts in-engine.
       - GITHUB_REF= dagger call -m dagger/preflight verdict --artifacts preflight-artifacts
@@ -1625,20 +1536,8 @@ tasks:
     requires:
       vars:
         - EXTERNAL_KUBECONFIG
-        - GHCR_USERNAME
-        - GHCR_TOKEN
     env:
       KUBECONFIG: '{{ .EXTERNAL_KUBECONFIG }}'
-      GHCR_USERNAME: '{{ .GHCR_USERNAME }}'
-      GHCR_TOKEN: '{{ .GHCR_TOKEN }}'
-    deps:
-      # Add GHCR auth to the cluster-wide pull secret so the kubelet can pull the
-      # private Klio images (shared with olm:preflight-operator).
-      - task: internal:ensure-ghcr-pull-secret
-        vars:
-          EXTERNAL_KUBECONFIG: '{{ .EXTERNAL_KUBECONFIG }}'
-          GHCR_USERNAME: '{{ .GHCR_USERNAME }}'
-          GHCR_TOKEN: '{{ .GHCR_TOKEN }}'
     vars:
       CERT_MANAGER_PACKAGE: 'openshift-cert-manager-operator'
       CERT_MANAGER_CHANNEL: 'stable-v1'
@@ -1656,31 +1555,12 @@ tasks:
           Run `task olm:catalog-source` first (or download the `klio-olm`
           artifact from the ci.yml `olm` job) before invoking this task.
     cmds:
-      - |
-        set -euo pipefail
-        # Full OpenShift (CRC) already provides OLM, the openshift-marketplace
-        # and openshift-operators namespaces (with a global OperatorGroup), the
-        # redhat-operators/certified-operators catalogs, the console.openshift.io
-        # CRDs, and a cluster pull secret for registry.redhat.io. GHCR auth for
-        # the cluster-wide pull secret is added by the
-        # internal:ensure-ghcr-pull-secret dependency; here we add the
-        # marketplace pull secret our own catalog references.
-
-        # Build a dockerconfigjson for GHCR from the username/token. We construct
-        # it explicitly rather than reading ~/.docker/config.json, which may use a
-        # credential helper that omits the inline auth string.
-        ghcr_secret=$(mktemp)
-        trap 'rm -f "${ghcr_secret}"' EXIT
-        auth=$(printf '%s:%s' "${GHCR_USERNAME}" "${GHCR_TOKEN}" | base64 | tr -d '\n')
-        printf '{"auths":{"ghcr.io":{"auth":"%s"}}}' "${auth}" > "${ghcr_secret}"
-
-        # The klio-catalog CatalogSource references this secret via spec.secrets
-        # so its grpc pod can pull the catalog image from GHCR.
-        kubectl create secret generic klio-pull-secret \
-          --type=kubernetes.io/dockerconfigjson \
-          --from-file=.dockerconfigjson="${ghcr_secret}" \
-          -n openshift-marketplace \
-          --dry-run=client -o yaml | kubectl apply -f -
+      # Full OpenShift (CRC) already provides OLM, the openshift-marketplace and
+      # openshift-operators namespaces (with a global OperatorGroup), the
+      # redhat-operators/certified-operators catalogs, the console.openshift.io
+      # CRDs, and a cluster pull secret for registry.redhat.io. The Klio
+      # operator, bundle, catalog and operand images are all public on ghcr.io,
+      # so no additional pull credentials are needed.
       - kubectl apply -f operator/klio-operator-catalog-source.yaml
       - kubectl -n openshift-marketplace wait
           --for=jsonpath='{.status.connectionState.lastObservedState}'=READY
@@ -1855,10 +1735,6 @@ tasks:
   integration:write-e2e-config-openshift:
     desc: Generate operator/test/e2e/e2e-config.openshift.yaml for an OpenShift run.
     run: once
-    requires:
-      vars:
-        - GHCR_USERNAME
-        - GHCR_TOKEN
     vars:
       OPERAND_IMAGE_REPOSITORY: '{{ .OPERAND_IMAGE_REPOSITORY | default "ghcr.io/cloudnative-pg/klio-testing" }}'
       OPERAND_IMAGE_TAG: '{{ .OPERAND_IMAGE_TAG | default .IMAGE_TAG }}'
@@ -1875,12 +1751,7 @@ tasks:
         operatorNamespace: "openshift-operators"
         operatorAppLabel: "app.kubernetes.io/name=klio-operator"
         operatorSubscription: "klio-operator"
-        imagePullSecret:
-          registry: "ghcr.io"
-          username: "{{ .GHCR_USERNAME }}"
-          password: "{{ .GHCR_TOKEN }}"
         EOF
-        chmod 0600 operator/test/e2e/e2e-config.openshift.yaml
 
   integration:setup-crc-storage:
     desc: Deploy expandable csi-hostpath storage on a CRC cluster (for PVCResize).
@@ -1917,8 +1788,9 @@ tasks:
       # Relative to dir (operator/test/e2e).
       E2E_CONFIG_FILE: e2e-config.openshift.yaml
     cmds:
-      # write-e2e-config-openshift (a dependency) generates this with the GHCR
-      # token in it; remove it when the run finishes, pass or fail.
+      # write-e2e-config-openshift (a dependency) generates this; remove it when
+      # the run finishes, pass or fail, so a later Kind run cannot pick up the
+      # OpenShift settings.
       - defer: rm -f "${E2E_CONFIG_FILE}"
       - mkdir -p e2e_cluster_logs
       - go test -timeout 30m -v ./...

--- a/core/internal/opentelemetry/wal_tier_test.go
+++ b/core/internal/opentelemetry/wal_tier_test.go
@@ -36,7 +36,7 @@ import (
 
 // TestServerWalTierCollapse verifies that tier-1 (walserver) and tier-2
 // (consumer) WAL recordings fold into a single instrument distinguished
-// by the `tier` attribute, per CNP-8324.
+// by the `tier` attribute.
 func TestServerWalTierCollapse(t *testing.T) {
 	reader := sdkmetric.NewManualReader()
 	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))

--- a/documentation/web/docs/developer/openshift_testing.md
+++ b/documentation/web/docs/developer/openshift_testing.md
@@ -58,8 +58,7 @@ on an OpenShift cluster using OLM (Operator Lifecycle Manager).
 
 :::note
 This procedure is for development and testing only. It requires
-a catalog image built from the branch under test and access to
-the `ghcr.io` container registry.
+a catalog image built from the branch under test.
 :::
 
 ## Prerequisites
@@ -68,31 +67,12 @@ the `ghcr.io` container registry.
 - Cluster admin privileges
 - cert-manager installed in the cluster (for TLS certificate
   creation)
-- A GitHub personal access token with `read:packages` scope
 - A catalog image built with `task olm:catalog ENVIRONMENT=testing`
 
-## 1. Create the pull secret
+The Klio operator, bundle, catalog and operand images are public
+on `ghcr.io`, so no pull secret is needed.
 
-Test builds are hosted on `ghcr.io`. Create the pull secret
-in both the `openshift-marketplace` namespace (for OLM to pull
-the catalog image) and in `openshift-operators` (for the
-operator image itself).
-
-```bash
-oc create secret docker-registry klio-pull-secret \
-  --docker-server=ghcr.io \
-  --docker-username=<github-username> \
-  --docker-password=<github-token> \
-  -n openshift-marketplace
-
-oc create secret docker-registry klio-pull-secret \
-  --docker-server=ghcr.io \
-  --docker-username=<github-username> \
-  --docker-password=<github-token> \
-  -n openshift-operators
-```
-
-## 2. Apply the CatalogSource
+## 1. Apply the CatalogSource
 
 A CI run creates a catalog image, tagged with the branch name or the PR number:
 
@@ -114,8 +94,6 @@ metadata:
 spec:
   sourceType: grpc
   image: <catalog-image>
-  secrets:
-    - klio-pull-secret
 ```
 
 Then apply it:
@@ -130,7 +108,7 @@ Wait for the catalog pod to become ready:
 oc get pods -n openshift-marketplace -w | grep klio
 ```
 
-## 3. Subscribe to the operator
+## 2. Subscribe to the operator
 
 Create an `openshift_subscription.yaml` file:
 
@@ -165,7 +143,7 @@ image by default, with the `klio` repository instead of
 `klio-operator`. The Subscription can override it.
 :::
 
-## 4. Create TLS certificates
+## 3. Create TLS certificates
 
 The Klio plugin requires two TLS secrets to establish mutual
 TLS with the CNPG operator:
@@ -240,27 +218,7 @@ oc get secrets -n openshift-operators \
   klio-plugin-server-tls klio-plugin-client-tls
 ```
 
-## 5. Link the pull secret to the service account
-
-The operator deployment pulls from the private registry.
-Link the pull secret to the operator's service account so
-that OpenShift injects it automatically:
-
-```bash
-oc secrets link klio-operator-controller-manager klio-pull-secret \
-  --for=pull \
-  -n openshift-operators
-```
-
-Then restart the operator pod to pick up the new pull
-credentials:
-
-```bash
-oc rollout restart deployment/klio-operator-controller-manager \
-  -n openshift-operators
-```
-
-## 6. Verify the installation
+## 4. Verify the installation
 
 The installation is complete when the CSV reaches the
 `Succeeded` phase. You can check its status with:
@@ -277,18 +235,18 @@ certification policies. Two checks cover the two artifacts:
 
 - **`check container`** — static policy checks on the operator image
   (labels, layers, license, base image). It needs no cluster and runs
-  in the Dagger engine on every PR via `task olm:preflight-container`
-  (see CNP-8641).
+  in the Dagger engine on every PR via `task olm:preflight-container`.
 - **`check operator`** — installs the bundle through OLM into a live
   OpenShift cluster and verifies it is deployable. Because it needs a
   real OpenShift cluster (OLM and Security Context Constraints), it runs
   via `task olm:preflight-operator`: in the OpenShift E2E CI job (against
   the CRC cluster it starts, before the e2e suite runs) and locally
-  against CRC. The bundle and catalog images are multi-arch
-  (`linux/amd64` and `linux/arm64`), so the check runs natively on either
-  architecture — including CRC on an Apple Silicon Mac.
+  against CRC. A failing check fails the job. The bundle and catalog
+  images are multi-arch (`linux/amd64` and `linux/arm64`), so the check
+  runs natively on either architecture — including CRC on an Apple
+  Silicon Mac.
 
-### Dry-run `check operator` against CRC
+### Run `check operator` against CRC
 
 Point `EXTERNAL_KUBECONFIG` at an OpenShift (CRC) cluster and run the
 task. The bundle and catalog (index) images must already be published
@@ -298,31 +256,12 @@ against the existing bundle rather than rebuilding it.
 
 ```bash
 export EXTERNAL_KUBECONFIG=/path/to/crc/kubeconfig
-export GHCR_USERNAME=<github-username>
-export GHCR_TOKEN=<github-token-with-read:packages>
 task olm:preflight-operator ENVIRONMENT=testing
 ```
-
-`GHCR_USERNAME` and `GHCR_TOKEN` are required: preflight uses them to
-pull the private `ghcr.io` bundle and index images, and the task adds
-them to the cluster-wide pull secret so the kubelet can pull the
-operator image once OLM installs it.
 
 preflight installs the operator through OLM, runs the operator policy,
 and the Dagger `preflight` module evaluates the pass/fail verdict
 in-engine. Raw artifacts are written to `operator/preflight-artifacts/`.
 
-### Submitting results to Red Hat (releases only)
-
-At release time the same task submits the results to Red Hat Pyxis. This
-is gated behind `SUBMIT=true` and requires the Pyxis credentials to be
-exported:
-
-```bash
-export PFLT_PYXIS_API_TOKEN=<pyxis-api-token>
-export PFLT_CERTIFICATION_COMPONENT_ID=<component-id>
-task olm:preflight-operator ENVIRONMENT=production SUBMIT=true
-```
-
-Without `SUBMIT=true` the task never contacts Red Hat, so it is safe to
-run for local validation.
+The task never contacts Red Hat: the checks are always evaluated
+locally.

--- a/documentation/web/docs/developer/running-e2e-tests.md
+++ b/documentation/web/docs/developer/running-e2e-tests.md
@@ -251,10 +251,21 @@ the pipeline requires:
 
 - A pre-built Klio OLM catalog artifact
   (`operator/klio-operator-catalog-source.yaml`)
-- A Red Hat pull secret (`REDHAT_REGISTRY_DOCKERCONFIG`) used to start
-  the CRC cluster
-- GHCR credentials (`GHCR_USERNAME`, `GHCR_TOKEN`) for the private Klio
-  images
+- A Red Hat pull secret (`REDHAT_PULL`) used to start the CRC cluster.
+  This is the same secret, under the same name, that cloudnative-pg uses
+  to install its own OpenShift test clusters.
+
+The Klio operator, bundle, catalog and operand images are public on
+`ghcr.io`, so no registry credentials are needed.
+
+:::note
+The Red Hat pull secret is not available to forks, so the
+`openshift-e2e` CI job is gated on the `OPENSHIFT_ENABLED` repository
+variable and is skipped unless a repository opts in. To run it on a
+fork, set the `OPENSHIFT_ENABLED` variable to `true` and add your own
+`REDHAT_PULL` secret. Running the suite locally against your own CRC
+cluster needs neither.
+:::
 
 ### Running locally
 
@@ -263,8 +274,6 @@ kubeconfig (CRC writes it to `~/.kube/config`):
 
 ```bash
 export EXTERNAL_KUBECONFIG="$HOME/.kube/config"
-export GHCR_USERNAME=<github-user>
-export GHCR_TOKEN=<github-token>
 
 # Generate the Klio OLM CatalogSource the deploy step requires (or
 # download the klio-olm artifact from the ci.yml olm job instead).
@@ -275,7 +284,6 @@ task integration:e2e-openshift
 
 This command will:
 
-- Add GHCR credentials to the cluster-wide pull secret
 - Deploy cert-manager, CNPG, and Klio via OLM subscriptions
 - Run the full e2e suite
 

--- a/operator/test/e2e/backup_test.go
+++ b/operator/test/e2e/backup_test.go
@@ -144,7 +144,7 @@ func newBackupFeature(
 	caIssuer := certificates.GetCAIssuerObject("test-ca-issuer", namespace, caCertificate.Spec.SecretName)
 
 	cnpgCluster := cnpg.GetCnpgClusterObject("test-cluster", namespace, instances, "klio-plugin-configuration",
-		cnpg.ClusterTemplateOptions{ImagePullSecret: pullSecretName(), StorageClass: testCfg.StorageClass})
+		cnpg.ClusterTemplateOptions{StorageClass: testCfg.StorageClass})
 
 	userCertificate := certificates.GetUserCertificateObject("klio-user", namespace, "klio-user@test-cluster", caIssuer)
 	klioPluginConfiguration := klio.GetPluginConfigurationObject(
@@ -163,7 +163,6 @@ func newBackupFeature(
 		klio.ServerTemplateOptions{
 			Image:              testCfg.ServerImage,
 			StorageClass:       testCfg.StorageClass,
-			ImagePullSecret:    pullSecretName(),
 			TLSSecretName:      certificate.Spec.SecretName,
 			ClientCASecretName: caCertificate.Spec.SecretName,
 			Encryption: klio.EncryptionOptions{

--- a/operator/test/e2e/common_test.go
+++ b/operator/test/e2e/common_test.go
@@ -46,32 +46,10 @@ import (
 
 const klioServerName = "test-klio-server"
 
-// imagePullSecretName is the fixed name of the pull secret created in each
-// test namespace when registry credentials are configured.
-const imagePullSecretName = "e2e-pull-secret" //nolint:gosec // This is a fixed name for the pull secret used in tests.
-
-// pullSecretName returns the pull secret name when registry credentials are
-// configured, or an empty string when they are not.
-func pullSecretName() string {
-	if testCfg.ImagePullSecret.IsConfigured() {
-		return imagePullSecretName
-	}
-
-	return ""
-}
-
-// createNamespace creates the namespace and, when registry credentials are
-// configured in testCfg, creates a dockerconfigjson pull secret inside it.
+// createNamespace creates the namespace used by a test.
 func createNamespace(ctx context.Context, t *testing.T, r *resources.Resources, ns *corev1.Namespace) {
 	t.Helper()
 	require.NoError(t, r.Create(ctx, ns), "failed to create namespace")
-	if !testCfg.ImagePullSecret.IsConfigured() {
-		return
-	}
-	cfg := testCfg.ImagePullSecret
-	secret := secrets.GetDockerConfigJSONSecret(
-		imagePullSecretName, ns.Name, cfg.Registry, cfg.Username, cfg.Password)
-	require.NoError(t, r.Create(ctx, secret), "failed to create pull secret")
 }
 
 // pluginTestResources holds the common Kubernetes resources needed by
@@ -116,7 +94,7 @@ func newPluginTestResources(namespace string) pluginTestResources {
 	)
 
 	cnpgCluster := cnpg.GetCnpgClusterObject("test-cluster", namespace, 1, "klio-plugin-configuration",
-		cnpg.ClusterTemplateOptions{ImagePullSecret: pullSecretName(), StorageClass: testCfg.StorageClass})
+		cnpg.ClusterTemplateOptions{StorageClass: testCfg.StorageClass})
 
 	ageSecrets := secrets.GetKlioAgeEncryptionSecrets("encryption", namespace, "testencryptionpassword123")
 	klioServer := klio.GetServerObject(
@@ -125,7 +103,6 @@ func newPluginTestResources(namespace string) pluginTestResources {
 		klio.ServerTemplateOptions{
 			Image:              testCfg.ServerImage,
 			StorageClass:       testCfg.StorageClass,
-			ImagePullSecret:    pullSecretName(),
 			TLSSecretName:      certificate.Spec.SecretName,
 			ClientCASecretName: caCertificate.Spec.SecretName,
 			Encryption: klio.EncryptionOptions{

--- a/operator/test/e2e/e2e-config.yaml.example
+++ b/operator/test/e2e/e2e-config.yaml.example
@@ -27,10 +27,3 @@ operatorAppLabel: "app.kubernetes.io/name=klio"
 # environment patch the Subscription (which OLM propagates to the Deployment)
 # instead of the Deployment, which OLM reverts. Leave empty for Helm/Kind.
 operatorSubscription: ""
-
-# Registry credentials used to create a pull secret in each test namespace.
-# Leave all fields empty if images are publicly accessible.
-imagePullSecret:
-  registry: ""
-  username: ""
-  password: ""

--- a/operator/test/e2e/otel_test.go
+++ b/operator/test/e2e/otel_test.go
@@ -163,7 +163,6 @@ func newOTELMetricsScenario(namespace string) *otelMetricsScenario {
 			ServerTemplateOptions: klio.ServerTemplateOptions{
 				Image:              testCfg.ServerImage,
 				StorageClass:       testCfg.StorageClass,
-				ImagePullSecret:    pullSecretName(),
 				TLSSecretName:      serverCertificate.Spec.SecretName,
 				ClientCASecretName: caCertificate.Spec.SecretName,
 				Encryption:         encOpts,
@@ -246,7 +245,7 @@ func newOTELMetricsScenario(namespace string) *otelMetricsScenario {
 
 	// CNPG Cluster with OTEL configuration
 	cnpgCluster := cnpg.GetCnpgClusterObject("test-cluster", namespace, 1, klioPluginConfiguration.Name,
-		cnpg.ClusterTemplateOptions{ImagePullSecret: pullSecretName(), StorageClass: testCfg.StorageClass})
+		cnpg.ClusterTemplateOptions{StorageClass: testCfg.StorageClass})
 
 	// Add OTEL env vars as Spec.Env (not EnvFrom) so the Klio lifecycle webhook
 	// merges them into the sidecar container.

--- a/operator/test/e2e/pvc_resize_test.go
+++ b/operator/test/e2e/pvc_resize_test.go
@@ -183,7 +183,6 @@ func NewPVCResizeFeatureConfig(name string, namespace string) klioFeatures.PVCRe
 		klio.ServerTemplateOptions{
 			Image:              testCfg.ServerImage,
 			StorageClass:       testCfg.StorageClass,
-			ImagePullSecret:    pullSecretName(),
 			TLSSecretName:      serverCertificate.Spec.SecretName,
 			ClientCASecretName: caCertificate.Spec.SecretName,
 			Encryption: klio.EncryptionOptions{

--- a/operator/test/e2e/recovery_test.go
+++ b/operator/test/e2e/recovery_test.go
@@ -54,7 +54,7 @@ func NewRecoveryFeatureConfig(
 
 	cnpgCluster := cnpg.GetCnpgClusterObject(cnpgSourceClusterName, namespace, instances,
 		"klio-plugin-configuration",
-		cnpg.ClusterTemplateOptions{ImagePullSecret: pullSecretName(), StorageClass: testCfg.StorageClass})
+		cnpg.ClusterTemplateOptions{StorageClass: testCfg.StorageClass})
 
 	userCertificate := certificates.GetUserCertificateObject("klio-user", namespace,
 		"klio-user@"+cnpgSourceClusterName, caIssuer)
@@ -74,7 +74,6 @@ func NewRecoveryFeatureConfig(
 		klio.ServerTemplateOptions{
 			Image:              testCfg.ServerImage,
 			StorageClass:       testCfg.StorageClass,
-			ImagePullSecret:    pullSecretName(),
 			TLSSecretName:      certificate.Spec.SecretName,
 			ClientCASecretName: caCertificate.Spec.SecretName,
 			Encryption: klio.EncryptionOptions{

--- a/operator/test/e2e/server_reconfig_test.go
+++ b/operator/test/e2e/server_reconfig_test.go
@@ -328,7 +328,6 @@ func ServerTierReconfiguration(namespace string) *serverReconfigFeature {
 		klio.ServerTemplateOptions{
 			Image:              testCfg.ServerImage,
 			StorageClass:       testCfg.StorageClass,
-			ImagePullSecret:    pullSecretName(),
 			TLSSecretName:      serverCertificate.Spec.SecretName,
 			ClientCASecretName: caCertificate.Spec.SecretName,
 			Encryption: klio.EncryptionOptions{

--- a/operator/test/e2e/tablespace_recovery_test.go
+++ b/operator/test/e2e/tablespace_recovery_test.go
@@ -73,7 +73,7 @@ func NewTablespaceRecoveryFeatureConfig(
 
 	cnpgCluster := cnpg.GetCnpgClusterWithTablespacesObject(cnpgSourceClusterName, namespace, instances,
 		"klio-plugin-configuration", tablespaceConfig,
-		cnpg.ClusterTemplateOptions{ImagePullSecret: pullSecretName(), StorageClass: testCfg.StorageClass})
+		cnpg.ClusterTemplateOptions{StorageClass: testCfg.StorageClass})
 
 	userCertificate := certificates.GetUserCertificateObject("klio-user", namespace,
 		"klio-user@"+cnpgSourceClusterName, caIssuer)
@@ -93,7 +93,6 @@ func NewTablespaceRecoveryFeatureConfig(
 		klio.ServerTemplateOptions{
 			Image:              testCfg.ServerImage,
 			StorageClass:       testCfg.StorageClass,
-			ImagePullSecret:    pullSecretName(),
 			TLSSecretName:      certificate.Spec.SecretName,
 			ClientCASecretName: caCertificate.Spec.SecretName,
 			Encryption: klio.EncryptionOptions{

--- a/operator/test/e2e/tier2_recovery_common_test.go
+++ b/operator/test/e2e/tier2_recovery_common_test.go
@@ -333,7 +333,6 @@ func buildTier2ScenarioResources(namespace string, instances int) *tier2Scenario
 			ServerTemplateOptions: klio.ServerTemplateOptions{
 				Image:              testCfg.ServerImage,
 				StorageClass:       testCfg.StorageClass,
-				ImagePullSecret:    pullSecretName(),
 				TLSSecretName:      serverCertificate.Spec.SecretName,
 				ClientCASecretName: caCertificate.Spec.SecretName,
 				Encryption:         encOpts,
@@ -354,7 +353,7 @@ func buildTier2ScenarioResources(namespace string, instances int) *tier2Scenario
 	// Source CNPG cluster
 	cnpgCluster := cnpg.GetCnpgClusterObject(
 		tier2SourceClusterName, namespace, instances, tier2SourcePluginConfigName,
-		cnpg.ClusterTemplateOptions{ImagePullSecret: pullSecretName(), StorageClass: testCfg.StorageClass})
+		cnpg.ClusterTemplateOptions{StorageClass: testCfg.StorageClass})
 
 	// Plugin configuration for source cluster (with tier2 backup enabled)
 	klioPluginConfigurationSource := klio.GetPluginConfigurationObject(
@@ -390,7 +389,6 @@ func buildTier2ScenarioResources(namespace string, instances int) *tier2Scenario
 			ServerTemplateOptions: klio.ServerTemplateOptions{
 				Image:              testCfg.ServerImage,
 				StorageClass:       testCfg.StorageClass,
-				ImagePullSecret:    pullSecretName(),
 				TLSSecretName:      recoveryServerCertificate.Spec.SecretName,
 				ClientCASecretName: recoveryServerCACertificate.Spec.SecretName,
 				Encryption:         encOpts, // SAME as first server

--- a/operator/test/e2e/tier2_retention_test.go
+++ b/operator/test/e2e/tier2_retention_test.go
@@ -227,7 +227,6 @@ func NewTier2RetentionFeatureConfig(
 			ServerTemplateOptions: klio.ServerTemplateOptions{
 				Image:              testCfg.ServerImage,
 				StorageClass:       testCfg.StorageClass,
-				ImagePullSecret:    pullSecretName(),
 				TLSSecretName:      serverCertificate.Spec.SecretName,
 				ClientCASecretName: caCertificate.Spec.SecretName,
 				Encryption: klio.EncryptionOptions{
@@ -258,7 +257,7 @@ func NewTier2RetentionFeatureConfig(
 	// CNPG cluster
 	cnpgCluster := cnpg.GetCnpgClusterObject(
 		cnpgClusterName, namespace, 1, pluginConfigurationName,
-		cnpg.ClusterTemplateOptions{ImagePullSecret: pullSecretName(), StorageClass: testCfg.StorageClass})
+		cnpg.ClusterTemplateOptions{StorageClass: testCfg.StorageClass})
 
 	// Plugin configuration with tier2 backup enabled and retention policy
 	klioPluginConfig := klio.GetPluginConfigurationObject(

--- a/operator/test/e2e/wal_retention_test.go
+++ b/operator/test/e2e/wal_retention_test.go
@@ -531,7 +531,6 @@ func newWALRetentionScenario(name string, namespace string) *walRetentionScenari
 			ServerTemplateOptions: klio.ServerTemplateOptions{
 				Image:              testCfg.ServerImage,
 				StorageClass:       testCfg.StorageClass,
-				ImagePullSecret:    pullSecretName(),
 				TLSSecretName:      serverCertificate.Spec.SecretName,
 				ClientCASecretName: caCertificate.Spec.SecretName,
 				Encryption: klio.EncryptionOptions{
@@ -562,7 +561,7 @@ func newWALRetentionScenario(name string, namespace string) *walRetentionScenari
 	// Source CNPG cluster
 	cnpgCluster := cnpg.GetCnpgClusterObject(
 		cnpgClusterName, namespace, 1, pluginConfigurationName,
-		cnpg.ClusterTemplateOptions{ImagePullSecret: pullSecretName(), StorageClass: testCfg.StorageClass})
+		cnpg.ClusterTemplateOptions{StorageClass: testCfg.StorageClass})
 
 	// Plugin configuration with tier2 backup enabled
 	klioPluginConfiguration := klio.GetPluginConfigurationObject(

--- a/operator/test/klio/testconfig/testconfig.go
+++ b/operator/test/klio/testconfig/testconfig.go
@@ -53,22 +53,6 @@ const (
 	envConfigFile     = "E2E_CONFIG_FILE"
 )
 
-// ImagePullSecretConfig holds registry credentials used to create a
-// kubernetes.io/dockerconfigjson pull secret in each test namespace.
-type ImagePullSecretConfig struct {
-	// Registry is the registry hostname (e.g. "ghcr.io").
-	Registry string `mapstructure:"registry"`
-	// Username is the registry username.
-	Username string `mapstructure:"username"`
-	// Password is the registry password or token.
-	Password string `mapstructure:"password"`
-}
-
-// IsConfigured returns true when all three credential fields are non-empty.
-func (c ImagePullSecretConfig) IsConfigured() bool {
-	return c.Registry != "" && c.Username != "" && c.Password != ""
-}
-
 // Config holds the e2e test configuration.
 type Config struct {
 	// ServerImage is the Klio server container image used in tests.
@@ -98,11 +82,6 @@ type Config struct {
 	// Deployment directly, which OLM reverts. Leave empty for the Helm/Kind
 	// install, where the Deployment is patched directly.
 	OperatorSubscription string `mapstructure:"operatorSubscription"`
-
-	// ImagePullSecret holds optional registry credentials. When all fields are
-	// non-empty, a pull secret named "e2e-pull-secret" is created in every test
-	// namespace and referenced by the Server and Cluster templates.
-	ImagePullSecret ImagePullSecretConfig `mapstructure:"imagePullSecret"`
 }
 
 // Load reads the e2e test configuration. It applies built-in defaults first,

--- a/operator/test/utils/templates/cnpg/cnpg.go
+++ b/operator/test/utils/templates/cnpg/cnpg.go
@@ -28,9 +28,6 @@ import (
 
 // ClusterTemplateOptions configures optional fields for CNPG cluster templates.
 type ClusterTemplateOptions struct {
-	// ImagePullSecret is the name of a Kubernetes secret used to pull images.
-	// If empty, no pull secret is configured.
-	ImagePullSecret string
 	// StorageClass is the storage class for the cluster's data (and tablespace)
 	// PVCs. If empty, the cluster's default storage class is used.
 	StorageClass string
@@ -67,12 +64,6 @@ func GetCnpgClusterObject(
 				},
 			}},
 		},
-	}
-
-	if opts.ImagePullSecret != "" {
-		cluster.Spec.ImagePullSecrets = []cnpgv1.LocalObjectReference{
-			{Name: opts.ImagePullSecret},
-		}
 	}
 
 	if opts.StorageClass != "" {

--- a/operator/test/utils/templates/klio/klio.go
+++ b/operator/test/utils/templates/klio/klio.go
@@ -137,10 +137,6 @@ type ServerTemplateOptions struct {
 	// storage class is used.
 	StorageClass string
 
-	// ImagePullSecret is the name of the Kubernetes secret used to pull the
-	// Klio server image. If empty, no pull secret is configured.
-	ImagePullSecret string
-
 	// TLSSecretName is the secret to be used to expose the Klio server.
 	TLSSecretName string
 
@@ -157,9 +153,6 @@ func newBaseServer(name, namespace string, opts ServerTemplateOptions) *kliov1al
 	imgCfg := kliov1alpha1.ImageConfiguration{
 		Image:           opts.Image,
 		ImagePullPolicy: corev1.PullAlways,
-	}
-	if opts.ImagePullSecret != "" {
-		imgCfg.ImagePullSecrets = []corev1.LocalObjectReference{{Name: opts.ImagePullSecret}}
 	}
 
 	return &kliov1alpha1.Server{

--- a/operator/test/utils/templates/secrets/secrets.go
+++ b/operator/test/utils/templates/secrets/secrets.go
@@ -21,8 +21,6 @@ package secrets
 
 import (
 	"bytes"
-	"encoding/base64"
-	"encoding/json"
 	"fmt"
 	"io"
 
@@ -89,34 +87,6 @@ func GetKlioAgeEncryptionSecrets(
 				"identity.txt": []byte(identityContent),
 			},
 		},
-	}
-}
-
-// dockerConfigJSON is the structure of a kubernetes.io/dockerconfigjson secret payload.
-type dockerConfigJSON struct {
-	Auths map[string]dockerConfigEntry `json:"auths"`
-}
-
-// dockerConfigEntry holds the base64-encoded "username:password" auth token for a single registry.
-type dockerConfigEntry struct {
-	Auth string `json:"auth"`
-}
-
-// GetDockerConfigJSONSecret returns a kubernetes.io/dockerconfigjson Secret
-// with credentials for a single registry.
-func GetDockerConfigJSONSecret(name, namespace, registry, username, password string) *corev1.Secret {
-	auth := base64.StdEncoding.EncodeToString([]byte(username + ":" + password))
-	payload, err := json.Marshal(dockerConfigJSON{
-		Auths: map[string]dockerConfigEntry{registry: {Auth: auth}},
-	})
-	if err != nil {
-		panic(fmt.Sprintf("marshalling dockerconfigjson: %v", err))
-	}
-
-	return &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
-		Type:       corev1.SecretTypeDockerConfigJson,
-		Data:       map[string][]byte{corev1.DockerConfigJsonKey: payload},
 	}
 }
 


### PR DESCRIPTION
The Klio operator, bundle, catalog and operand images are all public on ghcr.io, so the machinery that threaded registry credentials through the OpenShift install is no longer needed. Additionally, I made some tweaks to align Klio with cloudnative-pg.

Closes #35 