### PR TITLE
ci: restrict workflow permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,9 @@ on:
     branches:
       - main
 
-jobs:
+permissions: read-all
 
+jobs:
   change-triage:
     name: Check changed files
     runs-on: ubuntu-latest
@@ -147,6 +148,9 @@ jobs:
     # freshly built operand image from ghcr regardless of which module changed.
     if: needs.change-triage.outputs.core-changed == 'true' || needs.change-triage.outputs.run-openshift == 'true'
     runs-on: ${{ github.repository_owner == 'cloudnative-pg' && 'ubuntu-latest-16-cores' || 'ubuntu-latest' }}
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -189,6 +193,9 @@ jobs:
     # the freshly built operator image from ghcr regardless of what changed.
     if: needs.change-triage.outputs.operator-changed == 'true' || needs.change-triage.outputs.run-openshift == 'true'
     runs-on: ${{ github.repository_owner == 'cloudnative-pg' && 'ubuntu-latest-16-cores' || 'ubuntu-latest' }}
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -225,6 +232,9 @@ jobs:
       - change-triage
     if: needs.change-triage.outputs.core-changed == 'true' || needs.change-triage.outputs.operator-changed == 'true'
     runs-on: ${{ github.repository_owner == 'cloudnative-pg' && 'ubuntu-latest-16-cores' || 'ubuntu-latest' }}
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Checkout Klio
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -286,6 +296,9 @@ jobs:
       # The OpenShift Catalog is just for internal testing purpose until it won't.
       ENVIRONMENT: "testing"
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -344,6 +357,9 @@ jobs:
     needs:
       - change-triage
     runs-on: ${{ github.repository_owner == 'cloudnative-pg' && 'ubuntu-latest-16-cores' || 'ubuntu-latest' }}
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,12 +12,16 @@ on:
     branches:
       - main
 
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   change-triage:
     name: Check changed files
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       docs-changed: ${{ steps.event-filter.outputs.docs-changed || steps.paths-filter.outputs.docs-changed }}
       core-changed: ${{ steps.event-filter.outputs.core-changed || steps.paths-filter.outputs.core-changed }}
@@ -234,7 +238,6 @@ jobs:
     runs-on: ${{ github.repository_owner == 'cloudnative-pg' && 'ubuntu-latest-16-cores' || 'ubuntu-latest' }}
     permissions:
       contents: read
-      packages: write
     steps:
       - name: Checkout Klio
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -414,6 +417,9 @@ jobs:
       - operator
       - olm
     if: needs.change-triage.outputs.run-openshift == 'true'
+    permissions:
+      contents: read
+      packages: read
     uses: ./.github/workflows/openshift-e2e.yml
     with:
       catalog-artifact-name: klio-olm

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -16,7 +16,8 @@ concurrency:
   group: "pages"
   cancel-in-progress: false
 
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   build:

--- a/.github/workflows/refresh-licenses.yml
+++ b/.github/workflows/refresh-licenses.yml
@@ -6,15 +6,15 @@ on:
   schedule:
     - cron: "30 0 * * 1"
 
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   licenses:
     name: Refresh licenses
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -5,9 +5,14 @@ on:
     branches:
       - main
 
+permissions: read-all
+
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -5,14 +5,14 @@ on:
     branches:
       - main
 
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   release-please:
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7


### PR DESCRIPTION
Restrict the permission of the workflows to read-only. Give write permissions only to workflows that need them.

Closes #47