### PR TITLE
docs: add documentation link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@
 The name *Klio* is inspired by Clio, the muse of history, symbolizing the
 preservation and recovery of past events, which resonates with database backup
 
+Documentation for Klio is available at
+[https://cloudnative-pg.io/klio/](https://cloudnative-pg.io/klio/).
+
 > [!WARNING]
 > Klio is **experimental** and under active development. APIs, CRDs, and
 > behavior may change without notice, and it is not yet recommended for


### PR DESCRIPTION
Add a reference to the Klio documentation site (`https://cloudnative-pg.io/klio/`) right after the intro paragraph, following the convention used by `cloudnative-pg/plugin-barman-cloud`.

Fixes #50