### PR TITLE
ci: use renovate-config-validator from renovate image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,9 @@ jobs:
               - '.github/workflows/ci.yml'
             renovate-changed:
               - 'renovate.json'
+              - 'Taskfile.yml'
+              - '.github/actions/setup-dagger/**'
+              - '.github/workflows/ci.yml'
 
       - name: Evaluate branches
         id: event-filter

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -403,11 +403,12 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
 
+      - name: Setup dagger
+        uses: ./.github/actions/setup-dagger
+
       - name: Validate Renovate JSON
-        env:
-          # renovate: datasource=npm depName=renovate versioning=semver
-          RENOVATE_VERSION: 43.288.0
-        run: npx --yes --package renovate@${RENOVATE_VERSION} -- renovate-config-validator
+        run:
+          task renovate:validate
 
   openshift-e2e:
     name: OpenShift E2E

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1927,3 +1927,19 @@ tasks:
       - defer: rm -f "${E2E_CONFIG_FILE}"
       - mkdir -p e2e_cluster_logs
       - go test -timeout 30m -v ./...
+
+  renovate:validate:
+    desc: Validate the renovate configuration
+    run: once
+    vars:
+      # renovate: datasource=docker depName=renovate/renovate versioning=docker
+      RENOVATE_IMAGE_VERSION: 44.14.1@sha256:a34836ff19679185d51f78f84c5785c21cba57d28cdc2cd02bd88bb9024f235d
+    cmds:
+      - >
+        dagger core container from --address renovate/renovate
+        with-mounted-file --path /config/renovate.json --source ./renovate.json
+        with-workdir --path /config
+        with-exec --args renovate-config-validator --args "--strict" --args renovate.json
+        stdout
+    sources:
+      - renovate.json

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1936,7 +1936,7 @@ tasks:
       RENOVATE_IMAGE_VERSION: 44.14.1@sha256:a34836ff19679185d51f78f84c5785c21cba57d28cdc2cd02bd88bb9024f235d
     cmds:
       - >
-        dagger core container from --address renovate/renovate
+        dagger core container from --address renovate/renovate:{{ .RENOVATE_IMAGE_VERSION }}
         with-mounted-file --path /config/renovate.json --source ./renovate.json
         with-workdir --path /config
         with-exec --args renovate-config-validator --args "--strict" --args renovate.json


### PR DESCRIPTION
Avoid using npx to reduce the chances of malicious dependencies being run.

Closes #52