### PR TITLE
ci(taskfile): pin a known-good Helm for the Kind e2e deploy step

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1573,17 +1573,11 @@ tasks:
         sh: date +%s
     cmds:
       - kind get kubeconfig --name {{ .KIND_CLUSTER_NAME }} > {{ .KUBECONFIG_PATH }}
-      # alpine/k8s bundles whatever Helm was current at its own build time, which is currently
-      # v4.2.1 (helm/helm#32214: --wait can hang for the full timeout waiting on a hook's
-      # before-hook-creation deletion, e.g. cert-manager's startupapicheck) with no newer image
-      # tag available yet. Install a known-good Helm ourselves instead of relying on the base
-      # image's bundled version.
       - |
         dagger shell << "."
-        container | from alpine/k8s:{{ .ALPINE_K8S_VERSION }} |
-        with-mounted-file /kube/.config {{ .KUBECONFIG_PATH }} |
+        container | from alpine/k8s:{{ .ALPINE_K8S_VERSION }} | with-mounted-file /kube/.config {{ .KUBECONFIG_PATH }} |
         with-directory /chart operator/dist/chart |
-        with-exec -- sh -c "curl -fsSL https://get.helm.sh/helm-{{ .HELM_VERSION }}-linux-amd64.tar.gz | tar xz -C /tmp && mv /tmp/linux-amd64/helm /usr/local/bin/helm && chmod +x /usr/local/bin/helm" |
+        with-exec -- sh -c "curl https://raw.githubusercontent.com/helm/helm/refs/tags/{{ .HELM_VERSION }}/scripts/get-helm-4 | DESIRED_VERSION={{ .HELM_VERSION }} VERIFY_CHECKSUM=false sh" |
         with-env-variable KUBECONFIG /kube/.config |
         with-service-binding localhost tcp://127.0.0.1:{{ .KIND_HOSTPORT }} |
         with-exec -- sh -c "kubectl config set-cluster kind-{{ .KIND_CLUSTER_NAME }} --server=https://localhost:{{ .KIND_HOSTPORT }}" |

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1564,6 +1564,8 @@ tasks:
       OPERAND_IMAGE_TAG: '{{ .OPERAND_IMAGE_TAG | default "dev" }}'
       # renovate: datasource=docker depName=alpine/k8s versioning=docker
       ALPINE_K8S_VERSION: 1.36.2@sha256:44ef4942e171939b9c665a4a84beb80e2dcdb9a24330d4651cfdfd2e9deecc47
+      # renovate: datasource=github-releases depName=helm/helm versioning=semver
+      HELM_VERSION: 'v4.2.3'
       # renovate: datasource=helm depName=cert-manager versioning=semver registryUrl=https://charts.jetstack.io
       CERT_MANAGER_VERSION: 'v1.21.1'
       # Cache busting timestamp to prevent Dagger from caching helm deployments
@@ -1571,10 +1573,17 @@ tasks:
         sh: date +%s
     cmds:
       - kind get kubeconfig --name {{ .KIND_CLUSTER_NAME }} > {{ .KUBECONFIG_PATH }}
+      # alpine/k8s bundles whatever Helm was current at its own build time, which is currently
+      # v4.2.1 (helm/helm#32214: --wait can hang for the full timeout waiting on a hook's
+      # before-hook-creation deletion, e.g. cert-manager's startupapicheck) with no newer image
+      # tag available yet. Install a known-good Helm ourselves instead of relying on the base
+      # image's bundled version.
       - |
         dagger shell << "."
-        container | from alpine/k8s:{{ .ALPINE_K8S_VERSION }} | with-mounted-file /kube/.config {{ .KUBECONFIG_PATH }} |
+        container | from alpine/k8s:{{ .ALPINE_K8S_VERSION }} |
+        with-mounted-file /kube/.config {{ .KUBECONFIG_PATH }} |
         with-directory /chart operator/dist/chart |
+        with-exec -- sh -c "curl -fsSL https://get.helm.sh/helm-{{ .HELM_VERSION }}-linux-amd64.tar.gz | tar xz -C /tmp && mv /tmp/linux-amd64/helm /usr/local/bin/helm && chmod +x /usr/local/bin/helm" |
         with-env-variable KUBECONFIG /kube/.config |
         with-service-binding localhost tcp://127.0.0.1:{{ .KIND_HOSTPORT }} |
         with-exec -- sh -c "kubectl config set-cluster kind-{{ .KIND_CLUSTER_NAME }} --server=https://localhost:{{ .KIND_HOSTPORT }}" |

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1564,6 +1564,7 @@ tasks:
       OPERAND_IMAGE_TAG: '{{ .OPERAND_IMAGE_TAG | default "dev" }}'
       # renovate: datasource=docker depName=alpine/k8s versioning=docker
       ALPINE_K8S_VERSION: 1.36.2@sha256:44ef4942e171939b9c665a4a84beb80e2dcdb9a24330d4651cfdfd2e9deecc47
+      # TODO: remove the HELM_VERSION once the new alpine/k8s image fixes the issue that caused this PR: https://github.com/cloudnative-pg/klio/pull/57
       # renovate: datasource=github-releases depName=helm/helm versioning=semver
       HELM_VERSION: 'v4.2.3'
       # renovate: datasource=helm depName=cert-manager versioning=semver registryUrl=https://charts.jetstack.io
@@ -1571,6 +1572,7 @@ tasks:
       # Cache busting timestamp to prevent Dagger from caching helm deployments
       CACHE_BUST:
         sh: date +%s
+    # TODO: remove the Helm installation once the new alpine/k8s image fixes the issue that caused this PR: https://github.com/cloudnative-pg/klio/pull/57
     cmds:
       - kind get kubeconfig --name {{ .KIND_CLUSTER_NAME }} > {{ .KUBECONFIG_PATH }}
       - |


### PR DESCRIPTION
The `alpine/k8s:1.36.2` bundles Helm v4.2.1, which regressed WaitForDelete to hang for the full --wait timeout on a hook's before-hook-creation deletion (helm/helm#32214) even when the resource is already gone.
This intermittently stalls cert-manager's startupapicheck hook for minutes during `integration:deploy-to-kind` when running in CI.

The fix landed in Helm v4.2.2, but alpine/k8s hasn't published a newer image tag: its weekly build pipeline has been broken since 2026-07-26 by an unrelated bug (a curl call to the renamed bitnami-labs/sealed-secrets GitHub org isn't following the redirect).

Install Helm v4.2.3 directly in the Dagger pipeline instead of relying on whatever the base image bundles.

Assisted-by: Claude

Fixes #56 

BEGIN_COMMIT_OVERRIDE
ci(taskfile): pin a known-good Helm for the Kind e2e deploy step
END_COMMIT_OVERRIDE