### PR TITLE
feat: add klio.plugin.wal.restore_duration end-to-end metric

### DIFF
--- a/core/internal/cnpgi/metrics.go
+++ b/core/internal/cnpgi/metrics.go
@@ -53,6 +53,30 @@ func recordBackupSuccess(ctx context.Context, duration time.Duration) {
 		metric.WithAttributes(opentelemetry.OutcomeSuccess.Attribute()))
 }
 
+// recordWalRestore records the end-to-end duration of one plugin WAL restore,
+// tagged with outcome, cache_hit, tier and cluster_name. tier may be
+// empty and cacheHit false when the restore failed before a tier served it.
+func recordWalRestore(
+	ctx context.Context,
+	duration time.Duration,
+	success, cacheHit bool,
+	t tier,
+	clusterName string,
+) {
+	outcome := opentelemetry.OutcomeSuccess
+	if !success {
+		outcome = opentelemetry.OutcomeFailure
+	}
+
+	opentelemetry.PluginWal.RestoreDuration.Record(ctx, duration.Nanoseconds(),
+		metric.WithAttributes(
+			outcome.Attribute(),
+			opentelemetry.CacheHitOf(cacheHit).Attribute(),
+			opentelemetry.AttributeKeyTier.Of(string(t)),
+			opentelemetry.AttributeKeyClusterName.Of(clusterName),
+		))
+}
+
 // recordBackupFailure records a failed backup.
 func recordBackupFailure(ctx context.Context, duration time.Duration, err error) {
 	category := classifyRunBackupError(ctx, err)

--- a/core/internal/cnpgi/prefetcher.go
+++ b/core/internal/cnpgi/prefetcher.go
@@ -120,12 +120,14 @@ func newWALPrefetcher(
 }
 
 // Request retrieves a WAL file, using the prefetch cache if available.
-// It also triggers prefetching of subsequent WAL files.
-func (p *walPrefetcher) Request(ctx context.Context, walName, targetPath string) error {
+// It also triggers prefetching of subsequent WAL files. The returned bool
+// reports whether the WAL was served from the prefetch spool (a cache hit);
+// it is only meaningful when the error is nil.
+func (p *walPrefetcher) Request(ctx context.Context, walName, targetPath string) (bool, error) {
 	contextLogger := log.FromContext(ctx).WithValues("walName", walName)
 
 	// Try to get complete WAL from cache or download.
-	err := p.getCompleteWAL(ctx, walName, targetPath)
+	cacheHit, err := p.getCompleteWAL(ctx, walName, targetPath)
 	if err == nil {
 		// Success - trigger prefetch of next N complete WALs.
 		p.mu.Lock()
@@ -136,24 +138,25 @@ func (p *walPrefetcher) Request(ctx context.Context, walName, targetPath string)
 			p.triggerPrefetch(walName)
 		}
 
-		return nil
+		return cacheHit, nil
 	}
 
 	if !errors.Is(err, errWALNotFound) {
-		return err
+		return false, err
 	}
 
 	// Only a bare WAL segment can have a .partial variant, so don't fabricate a
 	// nonsensical "<name>.partial" request for a history or backup-label file:
 	// report it as missing and let the caller move on.
 	if !canHavePartial(walName) {
-		return err
+		return false, err
 	}
 
 	// Complete WAL not found - try partial (direct to target, no cache).
 	contextLogger.Debug("Complete WAL not found, trying partial")
 
-	return p.getPartialWAL(ctx, walName, targetPath)
+	// Partial WALs are never cached, so this is never a cache hit.
+	return false, p.getPartialWAL(ctx, walName, targetPath)
 }
 
 // canHavePartial reports whether walName could have a .partial variant. Only a
@@ -172,10 +175,13 @@ func (p *walPrefetcher) Close() error {
 	return p.downloadPool.Wait()
 }
 
-// getCompleteWAL retrieves a complete WAL file from cache or downloads it.
+// getCompleteWAL retrieves a complete WAL file from cache or downloads it. The
+// returned bool reports whether the file was served from a speculative prefetch
+// already waiting in the spool (a cache hit); it is only meaningful when the
+// error is nil. A rename fallback to a direct download is not a cache hit.
 //
 //nolint:cyclop // complexity is slightly over limit but refactoring would hurt readability
-func (p *walPrefetcher) getCompleteWAL(ctx context.Context, walName, targetPath string) error {
+func (p *walPrefetcher) getCompleteWAL(ctx context.Context, walName, targetPath string) (bool, error) {
 	contextLogger := log.FromContext(ctx).WithValues("walName", walName)
 
 	p.mu.Lock()
@@ -206,11 +212,11 @@ func (p *walPrefetcher) getCompleteWAL(ctx context.Context, walName, targetPath 
 	select {
 	case <-entry.done:
 	case <-ctx.Done():
-		return ctx.Err()
+		return false, ctx.Err()
 	}
 
 	if entry.err != nil {
-		return entry.err
+		return false, entry.err
 	}
 
 	// Rename from spool to target (atomic on same filesystem).
@@ -227,14 +233,14 @@ func (p *walPrefetcher) getCompleteWAL(ctx context.Context, walName, targetPath 
 		p.cleanupEntry(walName)
 		_ = os.Remove(entry.spoolPath)
 
-		// Download directly to target.
-		return p.downloadDirect(ctx, walName, targetPath)
+		// Download directly to target - no longer a cache hit.
+		return false, p.downloadDirect(ctx, walName, targetPath)
 	}
 
 	// Cleanup entry from map (file already moved).
 	p.cleanupEntry(walName)
 
-	return nil
+	return prefetchHit, nil
 }
 
 // downloadWALToFile downloads a WAL file to the specified path.

--- a/core/internal/cnpgi/wal.go
+++ b/core/internal/cnpgi/wal.go
@@ -97,6 +97,18 @@ func (w *walServiceImplementation) Restore(
 	walName := request.GetSourceWalName()
 	destinationPath := request.GetDestinationFileName()
 
+	// Record the end-to-end restore duration on every exit path. The
+	// closure reads the final values of success/info/clusterName, so failures —
+	// including the fast validation bail-outs below — are measured too.
+	var (
+		success     bool
+		info        restoreOutcome
+		clusterName string
+	)
+	defer func() {
+		recordWalRestore(ctx, time.Since(startCall), success, info.cacheHit, info.tier, clusterName)
+	}()
+
 	if walName == "" || destinationPath == "" {
 		contextLogger.Warning("WAL restore operation failed. WAL name and destination file name must be specified")
 		return nil, errors.New("source WAL name and destination file name must be provided")
@@ -107,6 +119,7 @@ func (w *walServiceImplementation) Restore(
 	if err := json.Unmarshal(request.GetClusterDefinition(), &cluster); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal cluster definition: %w", err)
 	}
+	clusterName = cluster.Name
 	podName, ok := os.LookupEnv("POD_NAME") // Ensure PODNAME is set in the environment
 	if !ok {
 		return nil, errors.New("POD_NAME environment variable is not set")
@@ -120,7 +133,7 @@ func (w *walServiceImplementation) Restore(
 		return nil, errors.New("no WAL repository found for the cluster")
 	}
 
-	err = w.restoreWAL(ctx, walName, destinationPath, confPath)
+	info, err = w.restoreWAL(ctx, walName, destinationPath, confPath)
 	if errors.Is(err, errWALNotFound) {
 		return &wal.WALRestoreResult{}, status.Errorf(codes.NotFound, "WAL file not found: %q", walName)
 	}
@@ -128,24 +141,34 @@ func (w *walServiceImplementation) Restore(
 		return nil, err
 	}
 
+	success = true
 	contextLogger.Info("WAL.Restore", "walName", request.GetSourceWalName(), "duration", time.Since(startCall))
 
 	return &wal.WALRestoreResult{}, nil
+}
+
+// restoreOutcome carries the observable facts about a completed restore that
+// are only known deep in the restore path, so Restore can tag its end-to-end
+// duration metric. On failure the fields hold whatever was known so far (tier
+// is the last one attempted; cacheHit is false).
+type restoreOutcome struct {
+	tier     tier
+	cacheHit bool
 }
 
 func (w *walServiceImplementation) restoreWAL(
 	ctx context.Context,
 	walName, destinationPath string,
 	configPath string,
-) error {
+) (restoreOutcome, error) {
 	cfg, err := config.NewFromFile(afero.NewOsFs(), configPath)
 	if err != nil {
-		return fmt.Errorf("while loading configuration from file %q: %w", configPath, err)
+		return restoreOutcome{}, fmt.Errorf("while loading configuration from file %q: %w", configPath, err)
 	}
 
 	tiers := availableTiers(cfg)
 	if len(tiers) == 0 {
-		return errors.New("no WAL tier configured")
+		return restoreOutcome{}, errors.New("no WAL tier configured")
 	}
 
 	// Try the previously-successful tier first, when both are available.
@@ -155,20 +178,20 @@ func (w *walServiceImplementation) restoreWAL(
 	}
 
 	for _, t := range tiers {
-		err := w.mgr.restoreWAL(ctx, walRestoreOptions{
+		cacheHit, err := w.mgr.restoreWAL(ctx, walRestoreOptions{
 			configFile: configPath,
 			targetTier: t,
 		}, walName, destinationPath)
 		if err == nil {
 			w.currentTier.Store(t)
-			return nil
+			return restoreOutcome{tier: t, cacheHit: cacheHit}, nil
 		}
 		if !errors.Is(err, errWALNotFound) {
-			return err
+			return restoreOutcome{tier: t}, err
 		}
 	}
 
-	return errWALNotFound
+	return restoreOutcome{}, errWALNotFound
 }
 
 // availableTiers returns the tiers the user has opted in to as recovery
@@ -297,15 +320,18 @@ func (mgr *grpcClientManager) setupSpoolDir(ctx context.Context, opts walRestore
 	return spoolDir, nil
 }
 
+// restoreWAL restores a single WAL file via the given tier's client. The
+// returned bool reports whether the file was served from the prefetch spool
+// (a cache hit); it is only meaningful when the error is nil.
 func (mgr *grpcClientManager) restoreWAL(
 	ctx context.Context,
 	opts walRestoreOptions,
 	walName string,
 	targetFileName string,
-) error {
+) (bool, error) {
 	client, err := mgr.getClient(ctx, opts)
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	return client.prefetcher.Request(ctx, walName, targetFileName)

--- a/core/internal/opentelemetry/attributes.go
+++ b/core/internal/opentelemetry/attributes.go
@@ -58,6 +58,34 @@ func (o Outcome) Attribute() attribute.KeyValue {
 	return AttributeKeyOutcome.Of(string(o))
 }
 
+// CacheHit identifies whether a plugin WAL restore was served from the local
+// prefetch spool (`true`) or required a fresh download from the Klio server
+// (`false`), used as the value of the `cache_hit` attribute.
+type CacheHit string
+
+const (
+	// CacheHitTrue marks a restore served from a speculative prefetch already
+	// waiting in the local spool.
+	CacheHitTrue CacheHit = "true"
+	// CacheHitFalse marks a restore that had to download the WAL (no prefetch
+	// hit, or a partial/fallback download).
+	CacheHitFalse CacheHit = "false"
+)
+
+// CacheHitOf maps a boolean prefetch-hit result to its CacheHit value.
+func CacheHitOf(hit bool) CacheHit {
+	if hit {
+		return CacheHitTrue
+	}
+
+	return CacheHitFalse
+}
+
+// Attribute returns the `cache_hit` attribute for this value.
+func (c CacheHit) Attribute() attribute.KeyValue {
+	return AttributeKeyCacheHit.Of(string(c))
+}
+
 // Stage identifies a single step in the per-block WAL pipeline, used as the
 // value of the `stage` attribute to split a block-duration histogram across
 // its constituent steps instead of emitting one instrument per step.
@@ -138,6 +166,9 @@ const (
 	// AttributeKeyPath is the attribute key for the WAL data-flow path (put or
 	// get) of a per-block WAL duration histogram.
 	AttributeKeyPath AttributeKey = "path"
+	// AttributeKeyCacheHit is the attribute key for whether a plugin WAL restore
+	// was served from the prefetch spool (true) or downloaded (false).
+	AttributeKeyCacheHit AttributeKey = "cache_hit"
 )
 
 // Of builds an OTEL string attribute with the attribute key and the given value.

--- a/core/internal/opentelemetry/catalog.go
+++ b/core/internal/opentelemetry/catalog.go
@@ -95,6 +95,8 @@ const (
 	PluginBackupInProgressMetric           = "klio.plugin.backup.in_progress"
 	PluginBackupRunsMetric                 = "klio.plugin.backup.runs"
 
+	PluginWalRestoreDurationMetric = "klio.plugin.wal.restore_duration"
+
 	ServerWalWrittenSizeMetric           = "klio.server.wal.written_size"
 	ServerWalWrittenMetric               = "klio.server.wal.written"
 	ServerWalLatestWrittenTimeMetric     = "klio.server.wal.latest_written_time"
@@ -226,6 +228,17 @@ type ClientWalMetrics struct {
 	Timeline      metric.Int64Gauge
 }
 
+// PluginWalMetrics holds OTel instruments the CNPG-I plugin records for WAL
+// restore. RestoreDuration is the end-to-end time the plugin takes to satisfy
+// one RESTORE_WAL request (config resolution, tier failover, prefetch lookup or
+// download, and the spool→destination rename). Each recording carries an
+// `outcome` (`success` / `failure`), a `cache_hit` (`true` when served from the
+// prefetch spool), a `tier` (which storage tier served it), and a
+// `cluster_name`.
+type PluginWalMetrics struct {
+	RestoreDuration metric.Int64Histogram
+}
+
 // Centralized metric instrument instances.
 //
 //nolint:gochecknoglobals
@@ -234,6 +247,7 @@ var (
 	ServerBackup ServerBackupMetrics
 	ServerWal    ServerWalMetrics
 	ClientWal    ClientWalMetrics
+	PluginWal    PluginWalMetrics
 )
 
 // All metric instruments are created when this package is loaded, in the
@@ -247,6 +261,7 @@ func init() {
 	InitServerBackupMetrics()
 	InitServerWalMetrics()
 	InitClientWalMetrics()
+	InitPluginWalMetrics()
 }
 
 // InitPluginBackupMetrics creates OTel instruments for backup lifecycle tracking.
@@ -470,5 +485,21 @@ func InitClientWalMetrics() {
 	)
 	ClientWal.Timeline, _ = meter.Int64Gauge(ClientWalTimelineMetric,
 		metric.WithDescription("Timeline ID the WAL streaming client is currently streaming."),
+	)
+}
+
+// InitPluginWalMetrics creates the OTel instrument for the plugin end-to-end WAL
+// restore path. It is called once when this package is loaded; tests can call it
+// again after swapping the meter provider to rebind the instrument.
+func InitPluginWalMetrics() {
+	meter := otel.Meter(Meter)
+
+	PluginWal.RestoreDuration, _ = meter.Int64Histogram(PluginWalRestoreDurationMetric,
+		metric.WithDescription("Distribution of end-to-end WAL restore durations measured by the "+
+			"CNPG-I plugin (the full RESTORE_WAL request: config resolution, tier failover, prefetch "+
+			"lookup or download, and spool→destination rename). The `outcome` attribute is `success` "+
+			"or `failure`; `cache_hit` is `true` when served from the prefetch spool; `tier` is the "+
+			"storage tier that served the restore; `cluster_name` identifies the PostgreSQL cluster."),
+		metric.WithUnit("ns"),
 	)
 }

--- a/core/internal/opentelemetry/metrics.go
+++ b/core/internal/opentelemetry/metrics.go
@@ -79,6 +79,7 @@ func WalDurationViews() []metric.View {
 		explicitBucketView(ClientWalBlockDurationMetric, walBlockDurationBuckets()),
 		explicitBucketView(ServerWalGetDurationMetric, walFileDurationBuckets()),
 		explicitBucketView(ServerWalUploadDurationMetric, walFileDurationBuckets()),
+		explicitBucketView(PluginWalRestoreDurationMetric, walFileDurationBuckets()),
 	}
 }
 

--- a/core/internal/opentelemetry/wal_duration_test.go
+++ b/core/internal/opentelemetry/wal_duration_test.go
@@ -56,6 +56,7 @@ func setupWalDurationProvider(t *testing.T) *sdkmetric.ManualReader {
 
 	opentelemetry.InitServerWalMetrics()
 	opentelemetry.InitClientWalMetrics()
+	opentelemetry.InitPluginWalMetrics()
 
 	return reader
 }
@@ -168,6 +169,45 @@ func TestClientWalBlockDurationSend(t *testing.T) {
 	stage, ok := dps[0].Attributes.Value(attribute.Key("stage"))
 	require.True(t, ok)
 	assert.Equal(t, string(opentelemetry.StageSend), stage.AsString())
+}
+
+// TestPluginWalRestoreDuration verifies the plugin end-to-end WAL restore
+// histogram records with the outcome, cache_hit, tier and cluster_name
+// attributes and that the per-file bucket boundaries are applied.
+func TestPluginWalRestoreDuration(t *testing.T) {
+	reader := setupWalDurationProvider(t)
+	ctx := context.Background()
+
+	opentelemetry.PluginWal.RestoreDuration.Record(ctx, 250_000_000,
+		metric.WithAttributes(
+			opentelemetry.OutcomeSuccess.Attribute(),
+			opentelemetry.CacheHitOf(true).Attribute(),
+			opentelemetry.Tier1.Attribute(),
+			opentelemetry.AttributeKeyClusterName.Of("cluster-a"),
+		))
+
+	dps := collectHistogram(t, reader, opentelemetry.PluginWalRestoreDurationMetric)
+	require.Len(t, dps, 1)
+
+	outcome, ok := dps[0].Attributes.Value(attribute.Key("outcome"))
+	require.True(t, ok, "data point must carry an outcome attribute")
+	assert.Equal(t, string(opentelemetry.OutcomeSuccess), outcome.AsString())
+
+	cacheHit, ok := dps[0].Attributes.Value(attribute.Key("cache_hit"))
+	require.True(t, ok, "data point must carry a cache_hit attribute")
+	assert.Equal(t, "true", cacheHit.AsString())
+
+	tier, ok := dps[0].Attributes.Value(attribute.Key("tier"))
+	require.True(t, ok, "data point must carry a tier attribute")
+	assert.Equal(t, string(opentelemetry.Tier1), tier.AsString())
+
+	cluster, ok := dps[0].Attributes.Value(attribute.Key("cluster_name"))
+	require.True(t, ok, "data point must carry a cluster_name attribute")
+	assert.Equal(t, "cluster-a", cluster.AsString())
+
+	// The per-file ladder must be in force (not a single +Inf bucket).
+	assert.Greater(t, len(dps[0].Bounds), 1,
+		"explicit per-file bucket boundaries must be applied to the restore histogram")
 }
 
 // TestClientWalTimeline verifies the client timeline gauge reports the most

--- a/observability/grafana/client.go
+++ b/observability/grafana/client.go
@@ -35,8 +35,10 @@ const clientWalMatcher = `k8s_namespace_name=~"$namespace",cluster_name=~"$clust
 // backup lifecycle (`klio.plugin.backup.*`, exported to Prometheus as
 // `klio_plugin_backup_*`) and the WAL streaming client it supervises as a
 // child process (`klio.client.wal.*`, exported as `klio_client_wal_*`).
-// Backup queries are scoped by $namespace; WAL streaming queries additionally
-// carry cluster_name and are scoped by $cluster.
+// It also records the end-to-end WAL restore latency the plugin serves to
+// PostgreSQL (`klio.plugin.wal.*`, exported as `klio_plugin_wal_*`).
+// Backup and plugin WAL queries are scoped by $namespace; WAL streaming
+// queries additionally carry cluster_name and are scoped by $cluster.
 func clientPanels() []sizedPanel {
 	return []sizedPanel{
 		// Current backup state.
@@ -131,5 +133,25 @@ func clientPanels() []sizedPanel {
 			"cluster. Most meaningful under active write load; on an idle or low-write cluster, WAL "+
 			"blocks are sent too infrequently for the underlying histogram_quantile to be reliable, so "+
 			"the line may look sparse or noisy rather than absent.")),
+
+		// WAL restore latency and throughput. The plugin records
+		// klio.plugin.wal.restore_duration for every RESTORE_WAL request it serves
+		// to PostgreSQL, exported as the klio_plugin_wal_restore_duration_nanoseconds
+		// histogram. Scoped by $namespace like the backup family.
+		sized(8, panelHeight, timeseriesPanel("WAL restore latency (p95) by cache hit", "ns",
+			query(
+				fmt.Sprintf("histogram_quantile(0.95, sum by (le, cache_hit) "+
+					"(rate(klio_plugin_wal_restore_duration_nanoseconds_bucket{%s}[$__rate_interval])))", nsMatcher),
+				"p95 cache_hit={{cache_hit}}"),
+		).Description("95th-percentile end-to-end WAL restore latency measured by the plugin, split by "+
+			"whether the WAL was served from the prefetch spool (cache_hit=true, no server round-trip) or "+
+			"downloaded. This is the latency PostgreSQL actually experiences during recovery.")),
+		sized(8, panelHeight, timeseriesPanel("WAL restore rate by outcome", "ops",
+			query(
+				fmt.Sprintf("sum by (outcome) "+
+					"(rate(klio_plugin_wal_restore_duration_nanoseconds_count{%s}[$__rate_interval]))", nsMatcher),
+				"{{outcome}}"),
+		).Description("Rate of WAL restore requests handled by the plugin, split by outcome (success or "+
+			"failure).")),
 	}
 }

--- a/observability/grafana/klio-dashboard.json
+++ b/observability/grafana/klio-dashboard.json
@@ -820,7 +820,7 @@
       },
       "gridPos": {
         "h": 6,
-        "w": 24,
+        "w": 16,
         "x": 0,
         "y": 19
       },
@@ -849,6 +849,108 @@
       }
     },
     {
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.95, sum by (le, cache_hit) (rate(klio_plugin_wal_restore_duration_nanoseconds_bucket{k8s_namespace_name=~\"$namespace\"}[$__rate_interval])))",
+          "instant": false,
+          "legendFormat": "p95 cache_hit={{cache_hit}}",
+          "range": true
+        }
+      ],
+      "title": "WAL restore latency (p95) by cache hit",
+      "description": "95th-percentile end-to-end WAL restore latency measured by the plugin, split by whether the WAL was served from the prefetch spool (cache_hit=true, no server round-trip) or downloaded. This is the latency PostgreSQL actually experiences during recovery.",
+      "transparent": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 16,
+        "y": 19
+      },
+      "repeatDirection": "h",
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "",
+          "sort": ""
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ns",
+          "custom": {
+            "gradientMode": "opacity",
+            "fillOpacity": 10
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (outcome) (rate(klio_plugin_wal_restore_duration_nanoseconds_count{k8s_namespace_name=~\"$namespace\"}[$__rate_interval]))",
+          "instant": false,
+          "legendFormat": "{{outcome}}",
+          "range": true
+        }
+      ],
+      "title": "WAL restore rate by outcome",
+      "description": "Rate of WAL restore requests handled by the plugin, split by outcome (success or failure).",
+      "transparent": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 25
+      },
+      "repeatDirection": "h",
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "",
+          "sort": ""
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "custom": {
+            "gradientMode": "opacity",
+            "fillOpacity": 10
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
       "type": "row",
       "collapsed": false,
       "title": "Server",
@@ -856,7 +958,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 25
+        "y": 31
       },
       "id": 0,
       "panels": []
@@ -886,7 +988,7 @@
         "h": 6,
         "w": 4,
         "x": 0,
-        "y": 26
+        "y": 32
       },
       "repeatDirection": "h",
       "options": {
@@ -943,7 +1045,7 @@
         "h": 6,
         "w": 4,
         "x": 4,
-        "y": 26
+        "y": 32
       },
       "repeatDirection": "h",
       "options": {
@@ -1001,7 +1103,7 @@
         "h": 6,
         "w": 4,
         "x": 8,
-        "y": 26
+        "y": 32
       },
       "repeatDirection": "h",
       "options": {
@@ -1059,7 +1161,7 @@
         "h": 6,
         "w": 4,
         "x": 12,
-        "y": 26
+        "y": 32
       },
       "repeatDirection": "h",
       "options": {
@@ -1116,7 +1218,7 @@
         "h": 6,
         "w": 4,
         "x": 16,
-        "y": 26
+        "y": 32
       },
       "repeatDirection": "h",
       "options": {
@@ -1174,7 +1276,7 @@
         "h": 6,
         "w": 4,
         "x": 20,
-        "y": 26
+        "y": 32
       },
       "repeatDirection": "h",
       "options": {
@@ -1232,7 +1334,7 @@
         "h": 6,
         "w": 4,
         "x": 0,
-        "y": 32
+        "y": 38
       },
       "repeatDirection": "h",
       "options": {
@@ -1289,7 +1391,7 @@
         "h": 6,
         "w": 4,
         "x": 4,
-        "y": 32
+        "y": 38
       },
       "repeatDirection": "h",
       "options": {
@@ -1346,7 +1448,7 @@
         "h": 6,
         "w": 4,
         "x": 8,
-        "y": 32
+        "y": 38
       },
       "repeatDirection": "h",
       "options": {
@@ -1403,7 +1505,7 @@
         "h": 6,
         "w": 4,
         "x": 12,
-        "y": 32
+        "y": 38
       },
       "repeatDirection": "h",
       "options": {
@@ -1460,7 +1562,7 @@
         "h": 6,
         "w": 4,
         "x": 16,
-        "y": 32
+        "y": 38
       },
       "repeatDirection": "h",
       "options": {
@@ -1517,7 +1619,7 @@
         "h": 6,
         "w": 4,
         "x": 20,
-        "y": 32
+        "y": 38
       },
       "repeatDirection": "h",
       "options": {
@@ -1574,7 +1676,7 @@
         "h": 6,
         "w": 8,
         "x": 0,
-        "y": 38
+        "y": 44
       },
       "repeatDirection": "h",
       "options": {
@@ -1642,7 +1744,7 @@
         "h": 6,
         "w": 8,
         "x": 8,
-        "y": 38
+        "y": 44
       },
       "repeatDirection": "h",
       "options": {
@@ -1703,7 +1805,7 @@
         "h": 6,
         "w": 8,
         "x": 16,
-        "y": 38
+        "y": 44
       },
       "repeatDirection": "h",
       "options": {
@@ -1764,7 +1866,7 @@
         "h": 6,
         "w": 8,
         "x": 0,
-        "y": 44
+        "y": 50
       },
       "repeatDirection": "h",
       "options": {
@@ -1822,7 +1924,7 @@
         "h": 6,
         "w": 8,
         "x": 8,
-        "y": 44
+        "y": 50
       },
       "repeatDirection": "h",
       "options": {
@@ -1873,7 +1975,7 @@
         "h": 6,
         "w": 8,
         "x": 16,
-        "y": 44
+        "y": 50
       },
       "repeatDirection": "h",
       "options": {
@@ -1924,7 +2026,7 @@
         "h": 6,
         "w": 8,
         "x": 0,
-        "y": 50
+        "y": 56
       },
       "repeatDirection": "h",
       "options": {
@@ -1975,7 +2077,7 @@
         "h": 6,
         "w": 8,
         "x": 8,
-        "y": 50
+        "y": 56
       },
       "repeatDirection": "h",
       "options": {
@@ -2026,7 +2128,7 @@
         "h": 6,
         "w": 8,
         "x": 16,
-        "y": 50
+        "y": 56
       },
       "repeatDirection": "h",
       "options": {
@@ -2097,7 +2199,7 @@
         "h": 6,
         "w": 8,
         "x": 0,
-        "y": 56
+        "y": 62
       },
       "repeatDirection": "h",
       "options": {
@@ -2168,7 +2270,7 @@
         "h": 6,
         "w": 8,
         "x": 8,
-        "y": 56
+        "y": 62
       },
       "repeatDirection": "h",
       "options": {
@@ -2239,7 +2341,7 @@
         "h": 6,
         "w": 8,
         "x": 16,
-        "y": 56
+        "y": 62
       },
       "repeatDirection": "h",
       "options": {
@@ -2290,7 +2392,7 @@
         "h": 6,
         "w": 12,
         "x": 0,
-        "y": 62
+        "y": 68
       },
       "repeatDirection": "h",
       "options": {
@@ -2341,7 +2443,7 @@
         "h": 6,
         "w": 12,
         "x": 12,
-        "y": 62
+        "y": 68
       },
       "repeatDirection": "h",
       "options": {
@@ -2392,7 +2494,7 @@
         "h": 6,
         "w": 12,
         "x": 0,
-        "y": 68
+        "y": 74
       },
       "repeatDirection": "h",
       "options": {
@@ -2443,7 +2545,7 @@
         "h": 6,
         "w": 12,
         "x": 12,
-        "y": 68
+        "y": 74
       },
       "repeatDirection": "h",
       "options": {
@@ -2477,7 +2579,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 74
+        "y": 80
       },
       "id": 0,
       "panels": []
@@ -2507,7 +2609,7 @@
         "h": 6,
         "w": 8,
         "x": 0,
-        "y": 75
+        "y": 81
       },
       "repeatDirection": "h",
       "options": {
@@ -2558,7 +2660,7 @@
         "h": 6,
         "w": 8,
         "x": 8,
-        "y": 75
+        "y": 81
       },
       "repeatDirection": "h",
       "options": {
@@ -2609,7 +2711,7 @@
         "h": 6,
         "w": 8,
         "x": 16,
-        "y": 75
+        "y": 81
       },
       "repeatDirection": "h",
       "options": {


### PR DESCRIPTION
The CNPG-I plugin's `RESTORE_WAL` path already timed how long it takes to restore a WAL file end-to-end, but only wrote it to the log. This exposes it as an OpenTelemetry histogram, so the latency PostgreSQL actually experiences during recovery becomes observable.

**Why not the existing `klio.server.wal.get_duration`?** That one times only the server-side handling of a single `WAL.Get` gRPC call. The plugin's end-to-end restore is a superset — it also covers repo/tier resolution, tier failover, the prefetch lookup, and the spool→destination rename. More importantly, prefetch cache hits never reach the server at all (they're served from the local spool with a rename), so `get_duration` records nothing for them — and those are the common, hot-path case during recovery. The server metric structurally can't represent restore latency.

**The metric:** `klio.plugin.wal.restore_duration`, an Int64 histogram in nanoseconds using the shared WAL-file bucket view (same shape as the server get/upload duration histograms). Attributes: `outcome` (success/failure), `cache_hit` (prefetch spool vs download), `tier`, and `cluster_name`. `cache_hit`/`tier` are threaded up from the prefetcher through `restoreWAL` via a small `restoreOutcome`; `Restore` records on every exit path via `defer`, so failures are measured too.

**Dashboard:** two panels in the Client / Plugin section — p95 restore latency split by `cache_hit`, and restore rate by `outcome`. `klio-dashboard.json` regenerated with the builder.