### PR TITLE
refactor(operator): drop dead ClusterName defaulting fallback

### DIFF
--- a/documentation/web/docs/user/backup_and_restore.md
+++ b/documentation/web/docs/user/backup_and_restore.md
@@ -240,7 +240,7 @@ spec:
   clientSecretName: my-client-credentials
   serverSecretName: klio-server-tls
 
-  # Optional: specify the original cluster name if different
+  # Required: the name of the original cluster that was backed up
   clusterName: my-cluster
 ```
 

--- a/documentation/web/docs/user/plugin_configuration.md
+++ b/documentation/web/docs/user/plugin_configuration.md
@@ -404,8 +404,10 @@ WALs will still exist on the Klio server.
 :::
 
 Whichever value you use, it must match the host name in the Common Name of the
-client certificate (`userName@hostName`), otherwise the connection to the Klio
-server is refused.
+client certificate (`userName@hostName`). For tier 1 base backups, a mismatch
+is rejected at connection time; for WAL streaming, a mismatch is not currently
+detected and can lead to WALs being stored or retrieved under the wrong
+cluster path.
 
 ### Tier 2 configuration
 

--- a/documentation/web/docs/user/plugin_configuration.md
+++ b/documentation/web/docs/user/plugin_configuration.md
@@ -403,6 +403,10 @@ server hits the same error, since the original cluster backups and
 WALs will still exist on the Klio server.
 :::
 
+Whichever value you use, it must match the host name in the Common Name of the
+client certificate (`userName@hostName`), otherwise the connection to the Klio
+server is refused.
+
 ### Tier 2 configuration
 
 Tier 2 provides secondary storage (typically object storage like S3) for

--- a/operator/internal/klioconfig/config.go
+++ b/operator/internal/klioconfig/config.go
@@ -87,7 +87,6 @@ const ConfigDataKey = "config.yaml"
 
 // GenerateConfig builds a config.Data from a PluginConfigurationSpec.
 // configKey is the configuration key (e.g. "klio-archive").
-// clusterName is the default cluster name when the PC doesn't set one.
 func GenerateConfig(
 	spec kliov1alpha1.PluginConfigurationSpec,
 	configKey string,

--- a/operator/internal/klioconfig/config.go
+++ b/operator/internal/klioconfig/config.go
@@ -252,9 +252,6 @@ func addExternalClusterConfiguration(
 		return fmt.Errorf("failed to get '%s' configuration, error: %w", ref, err)
 	}
 
-	if klioPluginConfiguration.Spec.ClusterName == "" {
-		klioPluginConfiguration.Spec.ClusterName = serverName
-	}
 	configurations[serverName].klioPluginConfiguration = klioPluginConfiguration
 
 	return nil
@@ -312,11 +309,6 @@ func getArchivePluginConfigurations(
 
 		return configurations, fmt.Errorf("failed to get '%s' configuration, error: %w", ref, err)
 	}
-	if klioPluginConfiguration.Spec.ClusterName == "" {
-		// if the host name is not set, use the cluster name as the host name
-		klioPluginConfiguration.Spec.ClusterName = cluster.Name
-	}
-
 	configurations[ArchiveConfigKey].klioPluginConfiguration = klioPluginConfiguration.DeepCopy()
 
 	return configurations, nil


### PR DESCRIPTION
`PluginConfiguration.spec.clusterName` is `Required` with `MinLength=1`, so the
API server rejects empty values. The two branches in `klioconfig` that defaulted
an empty `ClusterName` could no longer fire for any object written through the
current CRD, and they disagreed with each other anyway: one defaulted to the
external cluster's `serverName`, the other to `cluster.Name`.

This removes both, along with the stale comment claiming the cluster name
doubles as the host name.

A second commit tightens the documentation of the field: the restore example
still commented it as optional, and neither page mentioned that the value has to
match the host name in the client certificate's Common Name.

### Behavior note

Objects created while the field was still optional (v0.0.7 to v0.0.12) are not
revalidated on read, so they can still be served with an empty `clusterName`.
Such an object now fails at client configuration validation with
`invalid client config: cluster_name is empty` instead of being silently
defaulted; setting `clusterName` on the resource fixes it.

Closes #69