### PR TITLE
fix: bump release to 0.0.20

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -28,7 +28,7 @@
     ".": {}
   },
   "plugins": [ "sentence-case" ],
-  "release-as": "0.0.19",
+  "release-as": "0.0.20",
   "signoff": "Peggie <info@cloudnative-pg.io>",
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json"
 }


### PR DESCRIPTION
Previous releases were generated as immutable. This breaks the workflow, since goreleaser attaches the artifacts after the release is created.

Set as fix to trigger a new release.