### PR TITLE
chore(deps): drop stale leonardoce/afero-s3 renovate ignore rule

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -88,8 +88,7 @@
         "go"
       ],
       "matchPackageNames": [
-        "github.com/leonardoce/kopia",
-        "github.com/leonardoce/afero-s3"
+        "github.com/leonardoce/kopia"
       ],
       "enabled": false,
       "description": "These packages are replaced with forks - updates are ignored"


### PR DESCRIPTION
Klio no longer replaces `github.com/fclairamb/afero-s3` with a `leonardoce` fork; the replace directive was removed from `go.mod` previously and the module is used directly from upstream.
The ignore rule in `renovate.json` no longer matches anything.