### PR TITLE
ci: derive ghcr.io push target from GITHUB_REPOSITORY_OWNER

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,14 @@ jobs:
       # release-please PR branch, and on demand via workflow_dispatch — but
       # never automatically on a regular pull request.
       run-openshift: ${{ github.event_name == 'push' || github.head_ref == 'release-please--branches--main' || (github.event_name == 'workflow_dispatch' && inputs.run-openshift) }}
+      # False only for a pull_request opened from a fork. On pull_request,
+      # every context (secrets, vars, GITHUB_TOKEN, GITHUB_REPOSITORY_OWNER)
+      # resolves against the *base* repository regardless of whose commit is
+      # checked out, so GITHUB_TOKEN is read-only against a namespace the fork
+      # never asked to push to. Jobs/steps that push to ghcr.io must skip the
+      # push (mirrors cloudnative-pg/cloudnative-pg's continuous-integration.yml
+      # PUSH flag) when this is false.
+      same-repo: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -180,6 +188,8 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run CI task
+        env:
+          PUSH: ${{ needs.change-triage.outputs.same-repo }}
         run: |
           task core:ci
 
@@ -224,10 +234,16 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run CI task
+        env:
+          PUSH: ${{ needs.change-triage.outputs.same-repo }}
         run: |
           task operator:ci
 
       - name: Run Red Hat preflight certification
+        # Preflight pulls the just-pushed UBI image by reference, so it can
+        # only run when operator:ci actually pushed one (see the PUSH env
+        # above): a fork pull_request builds but never pushes.
+        if: needs.change-triage.outputs.same-repo == 'true'
         run: |
           # Certify the UBI variant of the operator image just built and pushed
           # by operator:ci. Preflight only accepts a Red Hat UBI base, so the
@@ -313,12 +329,19 @@ jobs:
       - operator
       # the bundle needs the core and operator images
 
+    # olm:all pushes and then resolves digests for the bundle/catalog images
+    # by reference, so it needs the core/operator images actually pushed to
+    # ghcr.io. A fork pull_request never gets that (see PUSH in the core/
+    # operator jobs), so skip the whole job rather than fail it — matching
+    # cloudnative-pg/cloudnative-pg, which doesn't require its analogous
+    # olm-bundle/preflight jobs for exactly this reason.
     if: |
       !cancelled() &&
       (needs.change-triage.outputs.operator-changed == 'true' ||
        needs.change-triage.outputs.run-openshift == 'true') &&
       needs.operator.result == 'success' &&
-      (needs.core.result == 'success' || needs.core.result == 'skipped')
+      (needs.core.result == 'success' || needs.core.result == 'skipped') &&
+      needs.change-triage.outputs.same-repo == 'true'
     env:
       ENVIRONMENT: "testing"
       SKIP_IMAGE_DIGESTS: >-
@@ -447,8 +470,8 @@ jobs:
     # pull secret configured, so a repository without it skips the job instead
     # of failing to start the CRC cluster.
     #
-    # The head-repository check is separate and necessary: on `pull_request`
-    # the `vars` context resolves against the *base* repository, so a PR from a
+    # The same-repo check is separate and necessary: on `pull_request` the
+    # `vars` context resolves against the *base* repository, so a PR from a
     # fork would otherwise see OPENSHIFT_ENABLED and be dispatched — but fork
     # PRs receive no secrets, so REDHAT_PULL would be empty and CRC bring-up
     # would fail. Contributors can still run this job inside their own fork by
@@ -456,8 +479,7 @@ jobs:
     if: |
       needs.change-triage.outputs.run-openshift == 'true' &&
       vars.OPENSHIFT_ENABLED == 'true' &&
-      (github.event_name != 'pull_request' ||
-       github.event.pull_request.head.repo.full_name == github.repository)
+      needs.change-triage.outputs.same-repo == 'true'
     permissions:
       contents: read
       packages: read

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -253,6 +253,7 @@ tasks:
     vars:
       TAG: '{{ .TAG | default .IMAGE_TAG }}'
       GITHUB_ACTIONS: '{{ .GITHUB_ACTIONS }}'
+      PUSH: '{{ .PUSH | default "true" }}'
     cmds:
       - task: internal:containerize
         vars:
@@ -261,6 +262,7 @@ tasks:
           REGISTRY: '{{ if .GITHUB_ACTIONS }}ghcr.io/{{ .REGISTRY_OWNER }}{{ else }}{{ .REGISTRY_NAME }}:{{ .REGISTRY_PORT }}{{ end }}'
           VERSION: "{{ .TAG }}"
           LATEST: "false"
+          PUSH: "{{ .PUSH }}"
           WORKDIR: "core"
 
   core:containerize-main:
@@ -430,6 +432,12 @@ tasks:
         - VERSION
         - LATEST
         - WORKDIR
+    vars:
+      # False only when the caller is validating a fork's pull_request, where
+      # GITHUB_TOKEN is read-only against REGISTRY_OWNER's ghcr.io namespace
+      # (see REGISTRY_OWNER above) and any push would be denied regardless of
+      # this build's own correctness. Every other caller pushes as before.
+      PUSH: '{{ .PUSH | default "true" }}'
     env:
       environment: "{{ .ENVIRONMENT }}"
       registry: "{{ .REGISTRY }}"
@@ -437,7 +445,7 @@ tasks:
       version: "{{ .VERSION }}"
       latest: "{{ .LATEST }}"
     cmds:
-      - dagger run docker buildx bake --builder {{ .BUILDER_NAME }} --push --metadata-file metadata.json
+      - dagger run docker buildx bake --builder {{ .BUILDER_NAME }} {{ if eq .PUSH "true" }}--push {{ end }}--metadata-file metadata.json
 
   internal:lint:
     desc: Run golangci-lint
@@ -544,6 +552,7 @@ tasks:
     vars:
       TAG: '{{ .TAG | default .IMAGE_TAG }}'
       GITHUB_ACTIONS: '{{ .GITHUB_ACTIONS }}'
+      PUSH: '{{ .PUSH | default "true" }}'
     cmds:
       - task: internal:containerize
         vars:
@@ -552,6 +561,7 @@ tasks:
           REGISTRY: '{{ if .GITHUB_ACTIONS }}ghcr.io/{{ .REGISTRY_OWNER }}{{ else }}{{ .REGISTRY_NAME }}:{{ .REGISTRY_PORT }}{{ end }}'
           VERSION: "{{ .TAG }}"
           LATEST: "false"
+          PUSH: "{{ .PUSH }}"
           WORKDIR: "operator"
 
   operator:containerize-main:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -11,6 +11,12 @@ vars:
   REGISTRY_NETWORK: klio
   REGISTRY_NAME: '{{ .REGISTRY_NAME | default "registry.dev" }}'
   REGISTRY_PORT: '{{ .REGISTRY_PORT | default 5000 }}'
+  # GitHub org/user that owns the ghcr.io namespace CI pushes images to.
+  # GITHUB_REPOSITORY_OWNER is set by GitHub Actions to whichever repo the
+  # workflow is actually running in, so a fork's own CI pushes to the fork's
+  # namespace instead of failing against cloudnative-pg's, which the fork has
+  # no write access to.
+  REGISTRY_OWNER: '{{ .GITHUB_REPOSITORY_OWNER | default "cloudnative-pg" }}'
   GIT_TAG_VERSION:
     sh: git describe --tags --match 'v*' | sed -e 's/^v//; s/-g[0-9a-f]\+$$//; s/-\([0-9]\+\)$$/-dev\1/'
   GITHUB_REF_NAME: '{{ .GITHUB_REF_NAME | default "dev" }}'
@@ -252,7 +258,7 @@ tasks:
         vars:
           ENVIRONMENT: "testing"
           INSECURE: '{{ if .GITHUB_ACTIONS }}false{{ else }}true{{ end }}'
-          REGISTRY: '{{ if .GITHUB_ACTIONS }}ghcr.io/cloudnative-pg{{ else }}{{ .REGISTRY_NAME }}:{{ .REGISTRY_PORT }}{{ end }}'
+          REGISTRY: '{{ if .GITHUB_ACTIONS }}ghcr.io/{{ .REGISTRY_OWNER }}{{ else }}{{ .REGISTRY_NAME }}:{{ .REGISTRY_PORT }}{{ end }}'
           VERSION: "{{ .TAG }}"
           LATEST: "false"
           WORKDIR: "core"
@@ -278,7 +284,7 @@ tasks:
         vars:
           ENVIRONMENT: "production"
           INSECURE: "false"
-          REGISTRY: "ghcr.io/cloudnative-pg"
+          REGISTRY: "ghcr.io/{{ .REGISTRY_OWNER }}"
           VERSION: "main"
           LATEST: "false"
           WORKDIR: "core"
@@ -302,7 +308,7 @@ tasks:
       - task: internal:containerize
         vars:
           ENVIRONMENT: "production"
-          REGISTRY: "ghcr.io/cloudnative-pg"
+          REGISTRY: "ghcr.io/{{ .REGISTRY_OWNER }}"
           INSECURE: "false"
           VERSION: "{{ .GITHUB_REF_NAME }}"
           LATEST: "true"
@@ -543,7 +549,7 @@ tasks:
         vars:
           ENVIRONMENT: "testing"
           INSECURE: '{{ if .GITHUB_ACTIONS }}false{{ else }}true{{ end }}'
-          REGISTRY: '{{ if .GITHUB_ACTIONS }}ghcr.io/cloudnative-pg{{ else }}{{ .REGISTRY_NAME }}:{{ .REGISTRY_PORT }}{{ end }}'
+          REGISTRY: '{{ if .GITHUB_ACTIONS }}ghcr.io/{{ .REGISTRY_OWNER }}{{ else }}{{ .REGISTRY_NAME }}:{{ .REGISTRY_PORT }}{{ end }}'
           VERSION: "{{ .TAG }}"
           LATEST: "false"
           WORKDIR: "operator"
@@ -569,7 +575,7 @@ tasks:
         vars:
           ENVIRONMENT: "production"
           INSECURE: "false"
-          REGISTRY: "ghcr.io/cloudnative-pg"
+          REGISTRY: "ghcr.io/{{ .REGISTRY_OWNER }}"
           VERSION: "main"
           LATEST: "false"
           WORKDIR: "operator"
@@ -591,7 +597,7 @@ tasks:
       - task: internal:containerize
         vars:
           ENVIRONMENT: "production"
-          REGISTRY: "ghcr.io/cloudnative-pg"
+          REGISTRY: "ghcr.io/{{ .REGISTRY_OWNER }}"
           INSECURE: "false"
           VERSION: "{{ .GITHUB_REF_NAME }}"
           LATEST: "true"
@@ -709,9 +715,9 @@ tasks:
       # version from the Chart.yaml file.
       - >
         GITHUB_REF= dagger -s call -m github.com/sagikazarmark/daggerverse/helm@${DAGGER_HELM_SHA}
-        with-registry-auth --address "ghcr.io/cloudnative-pg" --username "{{ .GITHUB_ACTOR }}" --secret env://GITHUB_TOKEN
+        with-registry-auth --address "ghcr.io/{{ .REGISTRY_OWNER }}" --username "{{ .GITHUB_ACTOR }}" --secret env://GITHUB_TOKEN
         push --pkg dist/chart/klio_chart.tgz
-        --registry "oci://ghcr.io/cloudnative-pg/"
+        --registry "oci://ghcr.io/{{ .REGISTRY_OWNER }}/"
     sources:
       - dist/chart/**/*
 
@@ -758,7 +764,7 @@ tasks:
           enum:
             ref: .ALLOWED_ENVS
     env:
-      registry: '{{ if .GITHUB_ACTIONS }}ghcr.io/cloudnative-pg{{ else }}{{ .REGISTRY_NAME }}:{{ .REGISTRY_PORT }}{{ end }}'
+      registry: '{{ if .GITHUB_ACTIONS }}ghcr.io/{{ .REGISTRY_OWNER }}{{ else }}{{ .REGISTRY_NAME }}:{{ .REGISTRY_PORT }}{{ end }}'
       insecure: '{{ if .GITHUB_ACTIONS }}false{{ else }}true{{ end }}'
       suffix: '{{ if ( ne .ENVIRONMENT "production" ) }}-testing{{end}}'
       tag: '{{ .TAG | default .IMAGE_TAG }}'
@@ -887,7 +893,7 @@ tasks:
       - internal:registry-network-connect
       - olm:bundle
     env:
-      registry: '{{ if .GITHUB_ACTIONS }}ghcr.io/cloudnative-pg{{ else }}{{ .REGISTRY_NAME }}:{{ .REGISTRY_PORT }}{{ end }}'
+      registry: '{{ if .GITHUB_ACTIONS }}ghcr.io/{{ .REGISTRY_OWNER }}{{ else }}{{ .REGISTRY_NAME }}:{{ .REGISTRY_PORT }}{{ end }}'
       insecure: '{{ if .GITHUB_ACTIONS }}false{{ else }}true{{ end }}'
       suffix: '{{ if ( ne .ENVIRONMENT "production" ) }}-testing{{end}}'
       tag: '{{ .TAG | default .IMAGE_TAG }}'
@@ -913,7 +919,7 @@ tasks:
           enum:
             ref: .ALLOWED_ENVS
     env:
-      registry: '{{ if .GITHUB_ACTIONS }}ghcr.io/cloudnative-pg{{ else }}{{ .REGISTRY_NAME }}:{{ .REGISTRY_PORT }}{{ end }}'
+      registry: '{{ if .GITHUB_ACTIONS }}ghcr.io/{{ .REGISTRY_OWNER }}{{ else }}{{ .REGISTRY_NAME }}:{{ .REGISTRY_PORT }}{{ end }}'
       insecure: '{{ if .GITHUB_ACTIONS }}false{{ else }}true{{ end }}'
       suffix: '{{ if ( ne .ENVIRONMENT "production" ) }}-testing{{end}}'
       tag: '{{ .TAG | default .IMAGE_TAG }}'
@@ -974,7 +980,7 @@ tasks:
           enum:
             ref: .ALLOWED_ENVS
     env:
-      registry: '{{ if .GITHUB_ACTIONS }}ghcr.io/cloudnative-pg{{ else }}{{ .REGISTRY_NAME }}:{{ .REGISTRY_PORT }}{{ end }}'
+      registry: '{{ if .GITHUB_ACTIONS }}ghcr.io/{{ .REGISTRY_OWNER }}{{ else }}{{ .REGISTRY_NAME }}:{{ .REGISTRY_PORT }}{{ end }}'
       insecure: '{{ if .GITHUB_ACTIONS }}false{{ else }}true{{ end }}'
       suffix: '{{ if ( ne .ENVIRONMENT "production" ) }}-testing{{end}}'
       tag: '{{ .TAG | default .IMAGE_TAG }}'
@@ -999,7 +1005,7 @@ tasks:
           enum:
             ref: .ALLOWED_ENVS
     env:
-      registry: '{{ if .GITHUB_ACTIONS }}ghcr.io/cloudnative-pg{{ else }}{{ .REGISTRY_NAME }}:{{ .REGISTRY_PORT }}{{ end }}'
+      registry: '{{ if .GITHUB_ACTIONS }}ghcr.io/{{ .REGISTRY_OWNER }}{{ else }}{{ .REGISTRY_NAME }}:{{ .REGISTRY_PORT }}{{ end }}'
       insecure: '{{ if .GITHUB_ACTIONS }}false{{ else }}true{{ end }}'
       suffix: '{{ if ( ne .ENVIRONMENT "production" ) }}-testing{{end}}'
       tag: '{{ .TAG | default .IMAGE_TAG }}'
@@ -1122,7 +1128,7 @@ tasks:
           enum:
             ref: .ALLOWED_ENVS
     env:
-      registry: '{{ if .GITHUB_ACTIONS }}ghcr.io/cloudnative-pg{{ else }}{{ .REGISTRY_NAME }}:{{ .REGISTRY_PORT }}{{ end }}'
+      registry: '{{ if .GITHUB_ACTIONS }}ghcr.io/{{ .REGISTRY_OWNER }}{{ else }}{{ .REGISTRY_NAME }}:{{ .REGISTRY_PORT }}{{ end }}'
       suffix: '{{ if ( ne .ENVIRONMENT "production" ) }}-testing{{end}}'
       tag: '{{ .TAG | default .IMAGE_TAG }}'
       # REGISTRY_AUTH_FILE is the registry credentials file preflight uses for
@@ -1888,7 +1894,7 @@ tasks:
     desc: Generate operator/test/e2e/e2e-config.openshift.yaml for an OpenShift run.
     run: once
     vars:
-      OPERAND_IMAGE_REPOSITORY: '{{ .OPERAND_IMAGE_REPOSITORY | default "ghcr.io/cloudnative-pg/klio-testing" }}'
+      OPERAND_IMAGE_REPOSITORY: '{{ .OPERAND_IMAGE_REPOSITORY | default (printf "ghcr.io/%s/klio-testing" .REGISTRY_OWNER) }}'
       OPERAND_IMAGE_TAG: '{{ .OPERAND_IMAGE_TAG | default .IMAGE_TAG }}'
       # csi-hostpath-sc is provisioned by setup-crc-csi-hostpath.sh and matches
       # the StorageClass the Kind path uses (allowVolumeExpansion: true).

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -16,7 +16,7 @@ vars:
   # workflow is actually running in, so a fork's own CI pushes to the fork's
   # namespace instead of failing against cloudnative-pg's, which the fork has
   # no write access to.
-  REGISTRY_OWNER: '{{ .GITHUB_REPOSITORY_OWNER | default "cloudnative-pg" }}'
+  REGISTRY_OWNER: '{{ .REGISTRY_OWNER | default .GITHUB_REPOSITORY_OWNER | default "cloudnative-pg" | lower }}'
   GIT_TAG_VERSION:
     sh: git describe --tags --match 'v*' | sed -e 's/^v//; s/-g[0-9a-f]\+$$//; s/-\([0-9]\+\)$$/-dev\1/'
   GITHUB_REF_NAME: '{{ .GITHUB_REF_NAME | default "dev" }}'
@@ -837,7 +837,7 @@ tasks:
       after the operator build (in CI, the olm job needs the operator job).
 
       Digest pinning is enabled only when running in GitHub Actions, where the
-      images live on ghcr.io. 
+      images live on ghcr.io.
 
       Resolution covers *every* image in the CSV, the operand included, so a
       caller that cannot guarantee the operand image was pushed for this ref


### PR DESCRIPTION
Fixes #233.

CI hardcoded `ghcr.io/cloudnative-pg` as the image push target in `Taskfile.yml`, so a fork running CI on its own repo (a push to the fork's own `main`, or a manual `workflow_dispatch` run) fails at the push step: the fork's `GITHUB_TOKEN` has `packages: write` on its own `ghcr.io/<owner>` namespace, not on cloudnative-pg's.

Added a `REGISTRY_OWNER` var derived from `GITHUB_REPOSITORY_OWNER` (falling back to `cloudnative-pg` outside CI) and used it everywhere the registry was hardcoded: core/operator `containerize-snapshot`/`containerize-main`, the `olm:*` image-push tasks, `operator:helm-publish`, and the OpenShift e2e job's operand image pull default, which needs to match whatever namespace the image was actually pushed to.

`release-publish.yml`'s tasks didn't need this on their own merits, since those jobs are already gated on `github.repository_owner == 'cloudnative-pg'`, but got the same mechanical substitution for consistency.