### PR TITLE
docs: add CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,9 @@
+# This file is generated from componentowners-policy.yaml in
+# cloudnative-pg/cnpg-infra — do not hand-edit, propose changes there instead.
+#
+# Path-scoped rules below always include the repo's own general owners
+# (the "*" line) in addition to their own specific teams/users, since
+# CODEOWNERS only honors the LAST matching pattern for a given path —
+# it does not merge an earlier, less-specific rule into a later one.
+
+* @cloudnative-pg/klio-owners @jlong49


### PR DESCRIPTION
Adds a basic `CODEOWNERS` file for this repository:

- `@cloudnative-pg/klio-owners` as owner of the whole repo (`*`)
- `@jlong49` (John Long) as an individual code owner/reviewer